### PR TITLE
Updated repository URL in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<name>HPE ALM Octane Common libraries for CI plugins</name>
 	<description>HPE ALM Octane common libraries for developing CI plugins for Octane</description>
-	<url>https://github.com/HPSoftware/octane-ci-java-sdk/</url>
+	<url>https://github.com/MicroFocus/octane-ci-java-sdk</url>
 	<organization>
 		<name>HPE</name>
 	</organization>
@@ -57,9 +57,9 @@
 	</modules>
 
 	<scm>
-		<connection>scm:git:ssh://github.com/HPSoftware/octane-ci-java-sdk.git</connection>
-		<developerConnection>scm:git:ssh://github.com/HPSoftware/octane-ci-java-sdk.git</developerConnection>
-		<url>https://github.com/HPSoftware/octane-ci-java-sdk</url>
+		<connection>scm:git:ssh://github.com/MicroFocus/octane-ci-java-sdk.git</connection>
+		<developerConnection>scm:git:ssh://github.com/MicroFocus/octane-ci-java-sdk.git</developerConnection>
+		<url>https://github.com/MicroFocus/octane-ci-java-sdk</url>
 		<tag>HEAD</tag>
 	</scm>
 	<issueManagement />


### PR DESCRIPTION
This repository has been moved from https://github.com/HPSoftware/octane-ci-java-sdk to https://github.com/MicroFocus/octane-ci-java-sdk. Even though github has a redirect in place, you might want to use the actual URL in the pom.xml.