### PR TITLE
handle runtime/on-demand client shut down gracefully

### DIFF
--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
@@ -94,8 +94,9 @@ final class OctaneClientImpl implements OctaneClient {
 				this.close();
 			} catch (Throwable throwable) {
 				logger.error("failed during shutdown of OctaneClient " + configurer.octaneConfiguration.getInstanceId(), throwable);
+			} finally {
+				logger.info("...OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " CLOSED");
 			}
-			logger.info("...OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " CLOSED");
 		}));
 
 		logger.info("OctaneClient initialized with instance ID: " + configurer.octaneConfiguration.getInstanceId() + ", shared space ID: " + configurer.octaneConfiguration.getSharedSpace());

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
@@ -89,7 +89,7 @@ final class OctaneClientImpl implements OctaneClient {
 
 		//  register shutdown hook to allow graceful shutdown of services/resources
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-			logger.info("closing OctaneClient as per Runtime shutdown request");
+			logger.info("closing OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " as per Runtime shutdown request");
 			this.close();
 		}));
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
@@ -90,7 +90,11 @@ final class OctaneClientImpl implements OctaneClient {
 		//  register shutdown hook to allow graceful shutdown of services/resources
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 			logger.info("closing OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " as per Runtime shutdown request...");
-			this.close();
+			try {
+				this.close();
+			} catch (Throwable throwable) {
+				logger.error("failed during shutdown of OctaneClient " + configurer.octaneConfiguration.getInstanceId(), throwable);
+			}
 			logger.info("...OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " CLOSED");
 		}));
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
@@ -89,8 +89,9 @@ final class OctaneClientImpl implements OctaneClient {
 
 		//  register shutdown hook to allow graceful shutdown of services/resources
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-			logger.info("closing OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " as per Runtime shutdown request");
+			logger.info("closing OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " as per Runtime shutdown request...");
 			this.close();
+			logger.info("...OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " CLOSED");
 		}));
 
 		logger.info("OctaneClient initialized with instance ID: " + configurer.octaneConfiguration.getInstanceId() + ", shared space ID: " + configurer.octaneConfiguration.getSharedSpace());

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
@@ -161,8 +161,7 @@ final class OctaneClientImpl implements OctaneClient {
 		return "OctaneClientImpl{ instanceId: " + configurer.octaneConfiguration.getInstanceId() + " }";
 	}
 
-	void close() {
-		//  shut down services
+	private void close() {
 		queueingService.shutdown();
 		bridgeService.shutdown();
 		coverageService.shutdown();
@@ -172,6 +171,11 @@ final class OctaneClientImpl implements OctaneClient {
 		testsService.shutdown();
 		vulnerabilitiesService.shutdown();
 		restService.obtainOctaneRestClient().shutdown();
+	}
+
+	void remove() {
+		//  shut down services
+		close();
 
 		//  clean storage
 		if (configurer.pluginServices.getAllowedOctaneStorage() != null) {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
@@ -87,6 +87,12 @@ final class OctaneClientImpl implements OctaneClient {
 		//  bridge init is the last one, to make sure we are not processing any task until all services are up
 		bridgeService = BridgeService.newInstance(configurer, restService, tasksProcessor);
 
+		//  register shutdown hook to allow graceful shutdown of services/resources
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+			logger.info("closing OctaneClient as per Runtime shutdown request");
+			this.close();
+		}));
+
 		logger.info("OctaneClient initialized with instance ID: " + configurer.octaneConfiguration.getInstanceId() + ", shared space ID: " + configurer.octaneConfiguration.getSharedSpace());
 	}
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
@@ -89,13 +89,14 @@ final class OctaneClientImpl implements OctaneClient {
 
 		//  register shutdown hook to allow graceful shutdown of services/resources
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-			logger.info("closing OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " as per Runtime shutdown request...");
+			String instanceId = configurer.octaneConfiguration.getInstanceId();
+			logger.info("closing OctaneClient " + instanceId + " as per Runtime shutdown request...");
 			try {
 				this.close();
 			} catch (Throwable throwable) {
-				logger.error("failed during shutdown of OctaneClient " + configurer.octaneConfiguration.getInstanceId(), throwable);
+				logger.error("failed during shutdown of OctaneClient " + instanceId, throwable);
 			} finally {
-				logger.info("...OctaneClient " + configurer.octaneConfiguration.getInstanceId() + " CLOSED");
+				logger.info("...OctaneClient " + instanceId + " CLOSED");
 			}
 		}));
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneSDK.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneSDK.java
@@ -168,7 +168,7 @@ public final class OctaneSDK {
 	}
 
 	/**
-	 * removes client while shutting down all of its services
+	 * removes client while shutting down all of its services and cleaning all used persistent storage
 	 *
 	 * @param client client to be shut down and removed
 	 * @return invalidated client or NULL if no such a client found
@@ -188,7 +188,7 @@ public final class OctaneSDK {
 
 		if (targetEntry != null) {
 			try {
-				((OctaneClientImpl) targetEntry.getValue()).close();
+				((OctaneClientImpl) targetEntry.getValue()).remove();
 			} catch (Throwable throwable) {
 				logger.error("failure detected while closing OctaneClient", throwable);
 			}

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/ClosableService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/ClosableService.java
@@ -1,0 +1,10 @@
+package com.hp.octane.integrations.services;
+
+public interface ClosableService {
+
+	/**
+	 * Shuts down all executors
+	 * - this method won't wait for executors termination
+	 */
+	void shutdown();
+}

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeService.java
@@ -16,10 +16,11 @@
 package com.hp.octane.integrations.services.bridge;
 
 import com.hp.octane.integrations.OctaneSDK;
+import com.hp.octane.integrations.services.ClosableService;
 import com.hp.octane.integrations.services.rest.RestService;
 import com.hp.octane.integrations.services.tasking.TasksProcessor;
 
-public interface BridgeService {
+public interface BridgeService extends ClosableService {
 
 	/**
 	 * Service instance producer - for internal usage only (protected by inaccessible configurer)

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
@@ -16,6 +16,7 @@
 package com.hp.octane.integrations.services.bridge;
 
 import com.hp.octane.integrations.OctaneSDK;
+import com.hp.octane.integrations.dto.general.CIServerTypes;
 import com.hp.octane.integrations.services.rest.OctaneRestClient;
 import com.hp.octane.integrations.services.rest.RestService;
 import com.hp.octane.integrations.services.tasking.TasksProcessor;
@@ -90,8 +91,8 @@ final class BridgeServiceImpl implements BridgeService {
 			//  get tasks, wait if needed and return with task or timeout or error
 			tasksJSON = getAbridgedTasks(
 					configurer.octaneConfiguration.getInstanceId(),
-					serverInfo.getType(),
-					serverInfo.getUrl(),
+					serverInfo.getType() == null ? CIServerTypes.UNKNOWN.value() : serverInfo.getType(),
+					serverInfo.getUrl() == null ? "" : serverInfo.getUrl(),
 					pluginInfo == null ? "" : pluginInfo.getVersion(),
 					client,
 					serverInfo.getImpersonatedUser() == null ? "" : serverInfo.getImpersonatedUser());

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
@@ -93,8 +93,8 @@ final class BridgeServiceImpl implements BridgeService {
 					configurer.octaneConfiguration.getInstanceId(),
 					serverInfo.getType() == null ? CIServerTypes.UNKNOWN.value() : serverInfo.getType(),
 					serverInfo.getUrl() == null ? "" : serverInfo.getUrl(),
-					pluginInfo == null ? "" : pluginInfo.getVersion(),
-					client,
+					pluginInfo == null || pluginInfo.getVersion() == null ? "" : pluginInfo.getVersion(),
+					client == null ? "" : client,
 					serverInfo.getImpersonatedUser() == null ? "" : serverInfo.getImpersonatedUser());
 
 			//  regardless of response - reconnect again to keep the light on

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
@@ -171,6 +171,9 @@ final class BridgeServiceImpl implements BridgeService {
 			OctaneTaskAbridged[] tasks = dtoFactory.dtoCollectionFromJson(tasksJSON, OctaneTaskAbridged[].class);
 			logger.info("parsed " + tasks.length + " tasks, processing...");
 			for (final OctaneTaskAbridged task : tasks) {
+				if (taskProcessingExecutors.isShutdown()) {
+					break;
+				}
 				taskProcessingExecutors.execute(() -> {
 					OctaneResultAbridged result = tasksProcessor.execute(task);
 					int submitStatus = putAbridgedResult(

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageService.java
@@ -18,6 +18,7 @@ package com.hp.octane.integrations.services.coverage;
 import com.hp.octane.integrations.OctaneSDK;
 import com.hp.octane.integrations.dto.connectivity.OctaneResponse;
 import com.hp.octane.integrations.dto.coverage.CoverageReportType;
+import com.hp.octane.integrations.services.ClosableService;
 import com.hp.octane.integrations.services.queueing.QueueingService;
 import com.hp.octane.integrations.services.rest.RestService;
 
@@ -27,7 +28,7 @@ import java.io.InputStream;
  * Coverage service provides a means to get and submit coverage to Octane
  */
 
-public interface CoverageService {
+public interface CoverageService extends ClosableService {
 
 	/**
 	 * Coverage Service instance producer - for internal usage only (protected by inaccessible configurer)

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/SonarService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/SonarService.java
@@ -17,6 +17,7 @@ package com.hp.octane.integrations.services.coverage;
 
 import com.hp.octane.integrations.OctaneSDK;
 import com.hp.octane.integrations.exceptions.SonarIntegrationException;
+import com.hp.octane.integrations.services.ClosableService;
 import com.hp.octane.integrations.services.queueing.QueueingService;
 
 /**
@@ -28,7 +29,7 @@ import com.hp.octane.integrations.services.queueing.QueueingService;
  * - push relevant convent to Octane
  */
 
-public interface SonarService {
+public interface SonarService extends ClosableService {
 
 	/**
 	 * Sonar integration Service instance producer - for internal usage only (protected by inaccessible configurer)

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsService.java
@@ -16,10 +16,11 @@
 package com.hp.octane.integrations.services.events;
 
 import com.hp.octane.integrations.OctaneSDK;
+import com.hp.octane.integrations.services.ClosableService;
 import com.hp.octane.integrations.services.rest.RestService;
 import com.hp.octane.integrations.dto.events.CIEvent;
 
-public interface EventsService {
+public interface EventsService extends ClosableService {
 
 	/**
 	 * Service instance producer - for internal usage only (protected by inaccessible configurer)

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsService.java
@@ -16,10 +16,11 @@
 package com.hp.octane.integrations.services.logs;
 
 import com.hp.octane.integrations.OctaneSDK;
+import com.hp.octane.integrations.services.ClosableService;
 import com.hp.octane.integrations.services.rest.RestService;
 import com.hp.octane.integrations.services.queueing.QueueingService;
 
-public interface LogsService {
+public interface LogsService extends ClosableService {
 
 	/**
 	 * Service instance producer - for internal usage only (protected by inaccessible configurer)

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/queueing/QueueingService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/queueing/QueueingService.java
@@ -18,9 +18,10 @@ package com.hp.octane.integrations.services.queueing;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.hp.octane.integrations.OctaneSDK;
+import com.hp.octane.integrations.services.ClosableService;
 import com.squareup.tape.ObjectQueue;
 
-public interface QueueingService {
+public interface QueueingService extends ClosableService {
 
 	/**
 	 * Service instance producer - for internal usage only (protected by inaccessible configurer)
@@ -57,12 +58,6 @@ public interface QueueingService {
 	 * @return initialized queue
 	 */
 	<T extends QueueItem> ObjectQueue<T> initFileQueue(String queueFileName, Class<T> targetType);
-
-	/**
-	 * Shuts down all queue services
-	 * - closing all persistent queues
-	 */
-	void shutdown();
 
 	@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 	@JsonIgnoreProperties(ignoreUnknown = true)

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsService.java
@@ -18,13 +18,14 @@ package com.hp.octane.integrations.services.tests;
 import com.hp.octane.integrations.OctaneSDK;
 import com.hp.octane.integrations.dto.connectivity.OctaneResponse;
 import com.hp.octane.integrations.dto.tests.TestsResult;
+import com.hp.octane.integrations.services.ClosableService;
 import com.hp.octane.integrations.services.queueing.QueueingService;
 import com.hp.octane.integrations.services.rest.RestService;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-public interface TestsService {
+public interface TestsService extends ClosableService {
 
 	/**
 	 * Service instance producer - for internal usage only (protected by inaccessible configurer)

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesService.java
@@ -16,10 +16,11 @@
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.OctaneSDK;
+import com.hp.octane.integrations.services.ClosableService;
 import com.hp.octane.integrations.services.queueing.QueueingService;
 import com.hp.octane.integrations.services.rest.RestService;
 
-public interface VulnerabilitiesService {
+public interface VulnerabilitiesService extends ClosableService {
 
 	/**
 	 * Service instance producer - for internal usage only (protected by inaccessible configurer)


### PR DESCRIPTION
upon OctaneClient shut down request we'd like to:
- close all opened queue files
- stop all executurs sevices (threading, queues)

remove flow will perform all the steps above + storage clean up