### PR TITLE
tech: adding ci server instane ID as a query parameter to the events send API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Typical SDK-based ALM Octane integrated CI Plugin development would walk along t
    2. to [push builds' artifacts](#providing-test-results) (tests results etc) to ALM Octane
 
 This Java SDK project has two sub-projects:
-- **integrations-sdk**, which is the main source of the CI Plugin SDK
-- **integrations-dto**, which contains the definition and building factory of all DTO objects used for communication with ALM Octane
+- **integrations-sdk**: the main source of the CI Plugin SDK
+- **integrations-dto**: the definition and building factory of all DTO objects used for communication with ALM Octane
 
 See the [Javadoc](#creating-javadoc) for more information about the CI Plugin SDK APIs.
 

--- a/integrations-dto/pom.xml
+++ b/integrations-dto/pom.xml
@@ -74,18 +74,6 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-
-		<plugins>
-			<plugin>
-				<artifactId>spotbugs-maven-plugin</artifactId>
-				<groupId>com.github.spotbugs</groupId>
-				<version>${spotbugs.version}</version>
-				<configuration>
-					<effort>max</effort>
-					<maxRank>20</maxRank>
-				</configuration>
-			</plugin>
-		</plugins>
 	</build>
 
 	<profiles>

--- a/integrations-dto/pom.xml
+++ b/integrations-dto/pom.xml
@@ -74,6 +74,18 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+
+		<plugins>
+			<plugin>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<groupId>com.github.spotbugs</groupId>
+				<version>${spotbugs.version}</version>
+				<configuration>
+					<effort>max</effort>
+					<maxRank>20</maxRank>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 
 	<profiles>

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOFactory.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOFactory.java
@@ -41,6 +41,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -177,8 +178,8 @@ public final class DTOFactory {
 			} else {
 				throw new RuntimeException(dto.getClass() + " is not supported in this flow");
 			}
-		} catch (JAXBException jaxbe) {
-			throw new RuntimeException("failed to serialize " + dto + " to XML", jaxbe);
+		} catch (JAXBException | UnsupportedEncodingException e) {
+			throw new RuntimeException("failed to serialize " + dto + " to XML", e);
 		}
 	}
 

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOInternalProviderBase.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOInternalProviderBase.java
@@ -24,6 +24,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -45,12 +47,12 @@ public abstract class DTOInternalProviderBase {
 
 	protected abstract <T extends DTOBase> T instantiateDTO(Class<T> targetType) throws InstantiationException, IllegalAccessException;
 
-	<T extends DTOBase> String toXml(T dto) throws JAXBException {
+	<T extends DTOBase> String toXml(T dto) throws JAXBException, UnsupportedEncodingException {
 		JAXBContext jaxbContext = JAXBContext.newInstance(this.getXMLAbles());
 		Marshaller marshaller = jaxbContext.createMarshaller();
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		marshaller.marshal(dto, baos);
-		return baos.toString();
+		return baos.toString(Charset.defaultCharset().name());
 	}
 
 	<T extends DTOBase> InputStream toXmlStream(T dto) throws JAXBException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/SonarServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/SonarServiceImpl.java
@@ -42,7 +42,9 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -195,7 +197,7 @@ class SonarServiceImpl implements SonarService {
 			} else {
 				return CONNECTION_FAILURE;
 			}
-		} catch (Exception e) {
+		} catch (URISyntaxException | IOException e) {
 			return CONNECTION_FAILURE;
 		}
 	}

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/entities/EntitiesServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/entities/EntitiesServiceImpl.java
@@ -279,9 +279,8 @@ final class EntitiesServiceImpl implements EntitiesService {
 
 	private static String resolveTemplate(String template, Map<String, ?> params) {
 		String result = template;
-		for (String param : params.keySet()) {
-			Object value = params.get(param);
-			result = result.replaceAll(Pattern.quote("{" + param + "}"), encodeParam(value == null ? "" : value.toString()));
+		for (Map.Entry<String, ?> param : params.entrySet()) {
+			result = result.replaceAll(Pattern.quote("{" + param + "}"), encodeParam(param.getValue() == null ? "" : param.getValue().toString()));
 		}
 		return result;
 	}

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsServiceImpl.java
@@ -65,8 +65,7 @@ final class EventsServiceImpl implements EventsService {
 	private final int EVENTS_CHUNK_SIZE = System.getProperty("octane.sdk.events.chunk-size") != null ? Integer.parseInt(System.getProperty("octane.sdk.events.chunk-size")) : 10;
 	private final int MAX_EVENTS_TO_KEEP = System.getProperty("octane.sdk.events.max-to-keep") != null ? Integer.parseInt(System.getProperty("octane.sdk.events.max-to-keep")) : 3000;
 	private final long NO_EVENTS_PAUSE = System.getProperty("octane.sdk.events.empty-list-pause") != null ? Integer.parseInt(System.getProperty("octane.sdk.events.empty-list-pause")) : 15000;
-	private final long OCTANE_CONFIGURATION_UNAVAILABLE_PAUSE = 20000;
-	private final long TEMPORARY_FAILURE_PAUSE = 15000;
+	private final long TEMPORARY_FAILURE_PAUSE = System.getProperty("octane.sdk.events.temp-fail-pause") != null ? Integer.parseInt(System.getProperty("octane.sdk.events.temp-fail-pause")) : 15000;
 
 	EventsServiceImpl(OctaneSDK.SDKServicesConfigurer configurer, RestService restService) {
 		if (configurer == null || configurer.pluginServices == null || configurer.octaneConfiguration == null) {
@@ -178,7 +177,7 @@ final class EventsServiceImpl implements EventsService {
 				.setMethod(HttpMethod.PUT)
 				.setUrl(configuration.getUrl() +
 						SHARED_SPACE_INTERNAL_API_PATH_PART + configuration.getSharedSpace() +
-						ANALYTICS_CI_PATH_PART + "events")
+						ANALYTICS_CI_PATH_PART + "events?ci_server_identity=" + configurer.octaneConfiguration.getInstanceId())
 				.setHeaders(headers)
 				.setBody(dtoFactory.dtoToJsonStream(eventsList));
 		OctaneResponse octaneResponse;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/RestServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/RestServiceImpl.java
@@ -49,7 +49,7 @@ final class RestServiceImpl implements RestService {
 	public OctaneRestClient obtainOctaneRestClient() {
 		if (defaultClient == null) {
 			synchronized (DEFAULT_CLIENT_INIT_LOCK) {
-				if (defaultClient == null) {
+				if (null == defaultClient) {
 					try {
 						defaultClient = new OctaneRestClientImpl(configurer);
 					} catch (Exception e) {
@@ -65,7 +65,7 @@ final class RestServiceImpl implements RestService {
 	public SSCRestClient obtainSSCRestClient() {
 		if (sscRestClient == null) {
 			synchronized (SSC_CLIENT_INIT_LOCK) {
-				if (sscRestClient == null) {
+				if (null == sscRestClient) {
 					try {
 						sscRestClient = new SSCRestClientImpl(configurer);
 					} catch (Exception e) {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
@@ -40,7 +40,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
@@ -39,6 +39,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -120,7 +122,7 @@ final class TestsServiceImpl implements TestsService {
 		}
 
 		String testsResultAsXml = dtoFactory.dtoToXml(testsResult);
-		InputStream testsResultAsStream = new ByteArrayInputStream(testsResultAsXml.getBytes());
+		InputStream testsResultAsStream = new ByteArrayInputStream(testsResultAsXml.getBytes(Charset.defaultCharset()));
 		return pushTestsResult(testsResultAsStream, jobId, buildId);
 	}
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/IssuesFileSerializer.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/IssuesFileSerializer.java
@@ -62,10 +62,8 @@ public class IssuesFileSerializer {
 
 	private void validateFolderExists() {
 		File file = new File(this.targetDir);
-		if (!file.exists()) {
-			if (!file.mkdirs()) {
-				throw new OctaneSDKGeneralException("target directory was missing and failed to create one");
-			}
+		if (!file.exists() && !file.mkdirs()) {
+			throw new OctaneSDKGeneralException("target directory was missing and failed to create one");
 		}
 	}
 }

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/IssuesFileSerializer.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/IssuesFileSerializer.java
@@ -11,13 +11,13 @@
  *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
- *
  */
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hp.octane.integrations.dto.securityscans.OctaneIssue;
+import com.hp.octane.integrations.exceptions.OctaneSDKGeneralException;
 import com.hp.octane.integrations.exceptions.PermanentException;
 
 import java.io.*;
@@ -26,46 +26,46 @@ import java.util.List;
 import java.util.Map;
 
 public class IssuesFileSerializer {
-    private String targetDir;
-    private List<OctaneIssue> octaneIssues;
+	private String targetDir;
+	private List<OctaneIssue> octaneIssues;
 
-    public IssuesFileSerializer(String targetDir, List<OctaneIssue> issues) {
-        this.targetDir = targetDir;
-        this.octaneIssues = issues;
-    }
+	public IssuesFileSerializer(String targetDir, List<OctaneIssue> issues) {
+		this.targetDir = targetDir;
+		this.octaneIssues = issues;
+	}
 
-    public InputStream doSerializeAndCache() {
-        try {
+	public InputStream doSerializeAndCache() {
+		try {
+			validateFolderExists();
+			Map<String, List<OctaneIssue>> dataFormat = new HashMap<>();
+			dataFormat.put("data", octaneIssues);
+			ObjectMapper mapper = new ObjectMapper();
+			mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-            validateFolderExists();
-            Map dataFormat = new HashMap<>();
-            dataFormat.put("data", octaneIssues);
-            ObjectMapper mapper = new ObjectMapper();
-            mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			mapper.writeValue(baos, dataFormat);
+			InputStream is = new ByteArrayInputStream(baos.toByteArray());
 
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            mapper.writeValue(baos, dataFormat);
-            InputStream is = new ByteArrayInputStream(baos.toByteArray());
+			//send to cache
+			if (targetDir != null) {
+				String vulnerabilitiesScanFilePath = targetDir + File.separator + SSCHandler.SCAN_RESULT_FILE;
+				PrintWriter fw = new PrintWriter(vulnerabilitiesScanFilePath, "UTF-8");
+				mapper.writeValue(fw, dataFormat);
+				fw.flush();
+				fw.close();
+			}
+			return is;
+		} catch (Exception e) {
+			throw new PermanentException(e);
+		}
+	}
 
-            //send to cache
-            if (targetDir != null) {
-                String vulnerabilitiesScanFilePath = targetDir + File.separator + SSCHandler.SCAN_RESULT_FILE;
-                PrintWriter fw = new PrintWriter(vulnerabilitiesScanFilePath, "UTF-8");
-                mapper.writeValue(fw, dataFormat);
-                fw.flush();
-                fw.close();
-            }
-            return is;
-        } catch (Exception e) {
-            throw new PermanentException(e);
-        }
-
-    }
-
-    private void validateFolderExists() {
-        File file = new File(this.targetDir);
-        if (!file.exists()) {
-            file.mkdirs();
-        }
-    }
+	private void validateFolderExists() {
+		File file = new File(this.targetDir);
+		if (!file.exists()) {
+			if (!file.mkdirs()) {
+				throw new OctaneSDKGeneralException("target directory was missing and failed to create one");
+			}
+		}
+	}
 }

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/SSCHandler.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/SSCHandler.java
@@ -22,7 +22,6 @@ import com.hp.octane.integrations.dto.entities.Entity;
 import com.hp.octane.integrations.dto.securityscans.OctaneIssue;
 import com.hp.octane.integrations.exceptions.PermanentException;
 import com.hp.octane.integrations.services.vulnerabilities.ssc.*;
-import com.hp.octane.integrations.utils.SdkStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -44,13 +43,13 @@ public class SSCHandler {
 	private long runStartTime;
 
 	public static final String SCAN_RESULT_FILE = "securityScan.json";
-	public static String SEVERITY_LG_NAME_LOW = "list_node.severity.low";
-	public static String SEVERITY_LG_NAME_MEDIUM = "list_node.severity.medium";
-	public static String SEVERITY_LG_NAME_HIGH = "list_node.severity.high";
-	public static String SEVERITY_LG_NAME_CRITICAL = "list_node.severity.urgent";
-	public static String EXTERNAL_TOOL_NAME = "Fortify SSC";
-	public static String ARTIFACT_STATUS_COMPLETE = "PROCESS_COMPLETE";
-	public static String ARTIFACT_ERROR_PROCESSING = "ERROR_PROCESSING";
+	public static final String SEVERITY_LG_NAME_LOW = "list_node.severity.low";
+	public static final String SEVERITY_LG_NAME_MEDIUM = "list_node.severity.medium";
+	public static final String SEVERITY_LG_NAME_HIGH = "list_node.severity.high";
+	public static final String SEVERITY_LG_NAME_CRITICAL = "list_node.severity.urgent";
+	public static final String EXTERNAL_TOOL_NAME = "Fortify SSC";
+	public static final String ARTIFACT_STATUS_COMPLETE = "PROCESS_COMPLETE";
+	public static final String ARTIFACT_ERROR_PROCESSING = "ERROR_PROCESSING";
 
 	public boolean isScanProcessFinished() {
 		logger.debug("enter isScanProcessFinished");

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
@@ -120,7 +120,6 @@ final class VulnerabilitiesServiceImpl implements VulnerabilitiesService {
 	}
 
 	//  TODO: implement retries counter per item and strategy of discard
-	//  TODO: distinct between the item's problem, server problem and env problem and retry strategy accordingly
 	//  TODO: consider moving the overall queue managing logic to some generic location
 	//  infallible everlasting background worker
 	private void worker() {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftExecutionUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftExecutionUtils.java
@@ -10,8 +10,10 @@ import org.w3c.dom.Element;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
@@ -20,9 +22,9 @@ import java.util.List;
 
 public class UftExecutionUtils {
 
-    private final static Logger logger = LogManager.getLogger(UftExecutionUtils.class);
+	private final static Logger logger = LogManager.getLogger(UftExecutionUtils.class);
 
-    public static String convertToMtbxContent(List<TestExecutionInfo> tests, String workingDir) {
+	public static String convertToMtbxContent(List<TestExecutionInfo> tests, String workingDir) {
         /*<Mtbx>
             <Test name="test1" path=workingDir + "\APITest1">
 			<DataTable path=workingDir+"\aa\bbb.xslx"/>
@@ -34,50 +36,49 @@ public class UftExecutionUtils {
 			</Test>
 		</Mtbx>*/
 
-        try {
-            DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
-            Document doc = docBuilder.newDocument();
-            Element rootElement = doc.createElement("Mtbx");
-            doc.appendChild(rootElement);
+		try {
+			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+			Document doc = docBuilder.newDocument();
+			Element rootElement = doc.createElement("Mtbx");
+			doc.appendChild(rootElement);
 
-            for (TestExecutionInfo test : tests) {
-                Element testElement = doc.createElement("Test");
-                String packageAndTestName = (SdkStringUtils.isNotEmpty(test.getPackageName())
-                        ? test.getPackageName() + SdkConstants.FileSystem.WINDOWS_PATH_SPLITTER
-                        : "")
-                        + test.getTestName();
-                testElement.setAttribute("name", packageAndTestName);
-                String path = workingDir + (SdkStringUtils.isEmpty(test.getPackageName())
-                        ? ""
-                        : SdkConstants.FileSystem.WINDOWS_PATH_SPLITTER + test.getPackageName())
-                        + SdkConstants.FileSystem.WINDOWS_PATH_SPLITTER + test.getTestName();
-                testElement.setAttribute("path", path);
+			for (TestExecutionInfo test : tests) {
+				Element testElement = doc.createElement("Test");
+				String packageAndTestName = (SdkStringUtils.isNotEmpty(test.getPackageName())
+						? test.getPackageName() + SdkConstants.FileSystem.WINDOWS_PATH_SPLITTER
+						: "")
+						+ test.getTestName();
+				testElement.setAttribute("name", packageAndTestName);
+				String path = workingDir + (SdkStringUtils.isEmpty(test.getPackageName())
+						? ""
+						: SdkConstants.FileSystem.WINDOWS_PATH_SPLITTER + test.getPackageName())
+						+ SdkConstants.FileSystem.WINDOWS_PATH_SPLITTER + test.getTestName();
+				testElement.setAttribute("path", path);
 
-                if (SdkStringUtils.isNotEmpty(test.getDataTable())) {
-                    Element dataTableElement = doc.createElement("DataTable");
-                    dataTableElement.setAttribute("path", workingDir + SdkConstants.FileSystem.WINDOWS_PATH_SPLITTER + test.getDataTable());
-                    testElement.appendChild(dataTableElement);
-                }
+				if (SdkStringUtils.isNotEmpty(test.getDataTable())) {
+					Element dataTableElement = doc.createElement("DataTable");
+					dataTableElement.setAttribute("path", workingDir + SdkConstants.FileSystem.WINDOWS_PATH_SPLITTER + test.getDataTable());
+					testElement.appendChild(dataTableElement);
+				}
 
-                rootElement.appendChild(testElement);
-            }
+				rootElement.appendChild(testElement);
+			}
 
-            TransformerFactory tf = TransformerFactory.newInstance();
-            Transformer transformer = tf.newTransformer();
-            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+			TransformerFactory tf = TransformerFactory.newInstance();
+			Transformer transformer = tf.newTransformer();
+			transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 
-            StringWriter writer = new StringWriter();
-            transformer.transform(new DOMSource(doc), new StreamResult(writer));
+			StringWriter writer = new StringWriter();
+			transformer.transform(new DOMSource(doc), new StreamResult(writer));
 
-            return writer.toString();
-        } catch (Exception e) {
-            String msg = "Failed to build MTBX content : " + e.getMessage();
-            logger.error(msg);
-            throw new RuntimeException(msg);
-        }
-
-    }
+			return writer.toString();
+		} catch (ParserConfigurationException | TransformerException e) {
+			String msg = "Failed to build MTBX content : " + e.getMessage();
+			logger.error(msg);
+			throw new RuntimeException(msg);
+		}
+	}
 }

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftTestDiscoveryUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftTestDiscoveryUtils.java
@@ -16,7 +16,6 @@
 package com.hp.octane.integrations.uft;
 
 import com.hp.octane.integrations.uft.items.*;
-import com.hp.octane.integrations.utils.CIPluginSDKUtils;
 import com.hp.octane.integrations.utils.SdkConstants;
 import com.hp.octane.integrations.utils.SdkStringUtils;
 import org.apache.logging.log4j.LogManager;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/AutomatedTest.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/AutomatedTest.java
@@ -11,7 +11,6 @@
  *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
- *
  */
 
 package com.hp.octane.integrations.uft.items;
@@ -28,135 +27,135 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class AutomatedTest implements SupportsMoveDetection, SupportsOctaneStatus {
 
-    @XmlAttribute
-    private String id;
-    @XmlAttribute
-    private String changeSetSrc;
-    @XmlAttribute
-    private String changeSetDst;
-    @XmlAttribute
-    private String oldName;
-    @XmlAttribute
-    private String oldPackageName;
-    @XmlAttribute
-    private Boolean isMoved;
-    @XmlAttribute
-    private UftTestType uftTestType;
-    @XmlAttribute
-    private OctaneStatus octaneStatus;
+	@XmlAttribute
+	private String id;
+	@XmlAttribute
+	private String changeSetSrc;
+	@XmlAttribute
+	private String changeSetDst;
+	@XmlAttribute
+	private String oldName;
+	@XmlAttribute
+	private String oldPackageName;
+	@XmlAttribute
+	private Boolean isMoved;
+	@XmlAttribute
+	private UftTestType uftTestType;
+	@XmlAttribute
+	private OctaneStatus octaneStatus;
 
-    @XmlAttribute
-    private String name;
-    @XmlAttribute
-    private String packageName;
-    @XmlAttribute
-    private Boolean executable;
+	@XmlAttribute
+	private String name;
+	@XmlAttribute
+	private String packageName;
+	@XmlAttribute
+	private Boolean executable;
 
-    private String description;
+	private String description;
 
-    public String getName() {
-        return name;
-    }
+	public String getName() {
+		return name;
+	}
 
-    public void setName(String name) {
-        this.name = name;
-    }
+	public void setName(String name) {
+		this.name = name;
+	}
 
-    public String getPackage() {
-        return packageName;
-    }
+	public String getPackage() {
+		return packageName;
+	}
 
-    public void setPackage(String packageName) {
-        this.packageName = packageName;
-    }
+	public void setPackage(String packageName) {
+		this.packageName = packageName;
+	}
 
-    public String getDescription() {
-        return description;
-    }
+	public String getDescription() {
+		return description;
+	}
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
+	public void setDescription(String description) {
+		this.description = description;
+	}
 
-    public void setUftTestType(UftTestType uftTestType) {
-        this.uftTestType = uftTestType;
-    }
+	public void setUftTestType(UftTestType uftTestType) {
+		this.uftTestType = uftTestType;
+	}
 
-    public UftTestType getUftTestType() {
-        return uftTestType;
-    }
+	public UftTestType getUftTestType() {
+		return uftTestType;
+	}
 
-    public String getId() {
-        return id;
-    }
+	public String getId() {
+		return id;
+	}
 
-    public void setId(String id) {
-        this.id = id;
-    }
+	public void setId(String id) {
+		this.id = id;
+	}
 
-    public Boolean getExecutable() {
-        return executable;
-    }
+	public Boolean getExecutable() {
+		return executable;
+	}
 
-    public void setExecutable(Boolean executable) {
-        this.executable = executable;
-    }
+	public void setExecutable(Boolean executable) {
+		this.executable = executable;
+	}
 
-    @Override
-    public String toString() {
-        return "#" + getId() == null ? "0" : getId() + " - " + getPackage() + "@" + getName();
-    }
+	@Override
+	public String toString() {
+		return "#" + (getId() == null ? "0" : getId()) + " - " + getPackage() + "@" + getName();
+	}
 
-    @Override
-    public String getChangeSetSrc() {
-        return changeSetSrc;
-    }
+	@Override
+	public String getChangeSetSrc() {
+		return changeSetSrc;
+	}
 
-    @Override
-    public void setChangeSetSrc(String changeSetSrc) {
-        this.changeSetSrc = changeSetSrc;
-    }
+	@Override
+	public void setChangeSetSrc(String changeSetSrc) {
+		this.changeSetSrc = changeSetSrc;
+	}
 
-    @Override
-    public String getChangeSetDst() {
-        return changeSetDst;
-    }
+	@Override
+	public String getChangeSetDst() {
+		return changeSetDst;
+	}
 
-    @Override
-    public void setChangeSetDst(String changeSetDst) {
-        this.changeSetDst = changeSetDst;
-    }
+	@Override
+	public void setChangeSetDst(String changeSetDst) {
+		this.changeSetDst = changeSetDst;
+	}
 
-    public String getOldName() {
-        return oldName;
-    }
+	public String getOldName() {
+		return oldName;
+	}
 
-    public void setOldName(String oldName) {
-        this.oldName = oldName;
-    }
+	public void setOldName(String oldName) {
+		this.oldName = oldName;
+	}
 
-    public String getOldPackage() {
-        return oldPackageName;
-    }
+	public String getOldPackage() {
+		return oldPackageName;
+	}
 
-    public void setOldPackage(String oldPackageName) {
-        this.oldPackageName = oldPackageName;
-    }
+	public void setOldPackage(String oldPackageName) {
+		this.oldPackageName = oldPackageName;
+	}
 
-    public Boolean getIsMoved() {
-        return isMoved == null ? false : isMoved;
-    }
+	public Boolean getIsMoved() {
+		return isMoved != null ? isMoved : false;
+	}
 
-    public void setIsMoved(Boolean moved) {
-        isMoved = moved;
-    }
+	public void setIsMoved(Boolean moved) {
+		isMoved = moved;
+	}
 
-    @Override
-    public OctaneStatus getOctaneStatus() {
-        return octaneStatus;
-    }
+	@Override
+	public OctaneStatus getOctaneStatus() {
+		return octaneStatus;
+	}
 
-    public void setOctaneStatus(OctaneStatus octaneStatus) {
-        this.octaneStatus = octaneStatus;
-    }
+	public void setOctaneStatus(OctaneStatus octaneStatus) {
+		this.octaneStatus = octaneStatus;
+	}
 }

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/ScmResourceFile.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/ScmResourceFile.java
@@ -11,7 +11,6 @@
  *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
- *
  */
 
 package com.hp.octane.integrations.uft.items;
@@ -28,99 +27,99 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ScmResourceFile implements SupportsMoveDetection, SupportsOctaneStatus {
 
-    @XmlAttribute
-    private String id;
-    @XmlAttribute
-    private String changeSetSrc;
-    @XmlAttribute
-    private String changeSetDst;
-    @XmlAttribute
-    private String oldRelativePath;
-    @XmlAttribute
-    private String oldName;
-    @XmlAttribute
-    private Boolean isMoved;
-    @XmlAttribute
-    private OctaneStatus octaneStatus;
+	@XmlAttribute
+	private String id;
+	@XmlAttribute
+	private String changeSetSrc;
+	@XmlAttribute
+	private String changeSetDst;
+	@XmlAttribute
+	private String oldRelativePath;
+	@XmlAttribute
+	private String oldName;
+	@XmlAttribute
+	private Boolean isMoved;
+	@XmlAttribute
+	private OctaneStatus octaneStatus;
 
-    private String name;
+	private String name;
 
-    private String relativePath;
+	private String relativePath;
 
-    public String getName() {
-        return name;
-    }
+	public String getName() {
+		return name;
+	}
 
-    public void setName(String name) {
-        this.name = name;
-    }
+	public void setName(String name) {
+		this.name = name;
+	}
 
-    public String getId() {
-        return id;
-    }
+	public String getId() {
+		return id;
+	}
 
-    public void setId(String id) {
-        this.id = id;
-    }
+	public void setId(String id) {
+		this.id = id;
+	}
 
-    public String getRelativePath() {
-        return relativePath;
-    }
+	public String getRelativePath() {
+		return relativePath;
+	}
 
-    public void setRelativePath(String relativePath) {
-        this.relativePath = relativePath;
-    }
+	public void setRelativePath(String relativePath) {
+		this.relativePath = relativePath;
+	}
 
-    @Override
-    public String getChangeSetSrc() {
-        return changeSetSrc;
-    }
+	@Override
+	public String getChangeSetSrc() {
+		return changeSetSrc;
+	}
 
-    @Override
-    public void setChangeSetSrc(String changeSetSrc) {
-        this.changeSetSrc = changeSetSrc;
-    }
+	@Override
+	public void setChangeSetSrc(String changeSetSrc) {
+		this.changeSetSrc = changeSetSrc;
+	}
 
-    @Override
-    public String getChangeSetDst() {
-        return changeSetDst;
-    }
+	@Override
+	public String getChangeSetDst() {
+		return changeSetDst;
+	}
 
-    @Override
-    public void setChangeSetDst(String changeSetDst) {
-        this.changeSetDst = changeSetDst;
-    }
+	@Override
+	public void setChangeSetDst(String changeSetDst) {
+		this.changeSetDst = changeSetDst;
+	}
 
-    public String getOldRelativePath() {
-        return oldRelativePath;
-    }
+	public String getOldRelativePath() {
+		return oldRelativePath;
+	}
 
-    public void setOldRelativePath(String oldRelativePath) {
-        this.oldRelativePath = oldRelativePath;
-    }
+	public void setOldRelativePath(String oldRelativePath) {
+		this.oldRelativePath = oldRelativePath;
+	}
 
-    public String getOldName() {
-        return oldName;
-    }
+	public String getOldName() {
+		return oldName;
+	}
 
-    public void setOldName(String oldName) {
-        this.oldName = oldName;
-    }
+	public void setOldName(String oldName) {
+		this.oldName = oldName;
+	}
 
-    public Boolean getIsMoved() {
-        return isMoved == null ? false : isMoved;
-    }
+	public Boolean getIsMoved() {
+		return isMoved != null ? isMoved : false;
+	}
 
-    public void setIsMoved(Boolean moved) {
-        isMoved = moved;
-    }
+	public void setIsMoved(Boolean moved) {
+		isMoved = moved;
+	}
 
-    @Override
-    public OctaneStatus getOctaneStatus() {
-        return octaneStatus;
-    }
+	@Override
+	public OctaneStatus getOctaneStatus() {
+		return octaneStatus;
+	}
 
-    public void setOctaneStatus(OctaneStatus octaneStatus) {
-        this.octaneStatus = octaneStatus;
-    }
+	public void setOctaneStatus(OctaneStatus octaneStatus) {
+		this.octaneStatus = octaneStatus;
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 		<easymock.version>3.5.1</easymock.version>
 		<maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
 		<jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
-		<spotbugs.version>3.1.6</spotbugs.version>
+		<spotbugs.version>3.1.8</spotbugs.version>
 	</properties>
 
 	<dependencyManagement>
@@ -189,7 +189,7 @@
 					<version>${spotbugs.version}</version>
 					<configuration>
 						<effort>max</effort>
-						<maxRank>13</maxRank>
+						<maxRank>20</maxRank>
 					</configuration>
 					<executions>
 						<execution>


### PR DESCRIPTION
send API supports ci server instance ID as query parameter in Octane from 2016, we should use it rather than passing that info within the serialized body
improving code quality with SpotBugs