### PR TITLE
 defect #751097: improving handling of Octane unavailability

### DIFF
--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
@@ -141,6 +141,9 @@ final class BridgeServiceImpl implements BridgeService {
 					logger.debug("no tasks found on server");
 				} else if (octaneResponse.getStatus() == HttpStatus.SC_REQUEST_TIMEOUT) {
 					logger.debug("expected timeout disconnection on retrieval of abridged tasks");
+				} else if (octaneResponse.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || octaneResponse.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
+					logger.error("Octane service unavailable, breathing and will retry");
+					CIPluginSDKUtils.doWait(10000);
 				} else if (octaneResponse.getStatus() == HttpStatus.SC_UNAUTHORIZED) {
 					logger.error("connection to Octane failed: authentication error");
 					CIPluginSDKUtils.doWait(9000);

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
@@ -243,7 +243,7 @@ final class TestsServiceImpl implements TestsService {
 		//  push
 		try {
 			OctaneResponse response = pushTestsResult(testsResult, queueItem.jobId, queueItem.buildId);
-			if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE) {
+			if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
 				throw new TemporaryException("push request TEMPORARILY failed with status " + response.getStatus());
 			} else if (response.getStatus() != HttpStatus.SC_ACCEPTED) {
 				throw new PermanentException("push request PERMANENTLY failed with status " + response.getStatus());

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
@@ -173,7 +173,7 @@ final class VulnerabilitiesServiceImpl implements VulnerabilitiesService {
 				return false;
 			}
 		}
-		if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE) {
+		if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
 			throw new TemporaryException("vulnerabilities preflight request FAILED, service unavailable");
 		} else {
 			throw new PermanentException("vulnerabilities preflight request FAILED with " + response.getStatus() + "");


### PR DESCRIPTION
Currently, most of the REST services assume Octane to be temporary unavailable only when 503 status received of IOException.
Yet, since it is very likely that Octane will be behind LB and LBs usually will translate server's 503 into 502, we should handle 502 in a similar way.