### PR TITLE
tech: raising the sleeping time on 401/403 in bridge + adding sleepin…

### DIFF
--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
@@ -140,19 +140,19 @@ final class BridgeServiceImpl implements BridgeService {
 				if (octaneResponse.getStatus() == HttpStatus.SC_NO_CONTENT) {
 					logger.debug("no tasks found on server");
 				} else if (octaneResponse.getStatus() == HttpStatus.SC_REQUEST_TIMEOUT) {
-					logger.debug("expected timeout disconnection on retrieval of abridged tasks");
+					logger.debug("expected timeout disconnection on retrieval of abridged tasks, reconnecting immediately...");
 				} else if (octaneResponse.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || octaneResponse.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
 					logger.error("Octane service unavailable, breathing and will retry");
 					CIPluginSDKUtils.doWait(10000);
 				} else if (octaneResponse.getStatus() == HttpStatus.SC_UNAUTHORIZED) {
 					logger.error("connection to Octane failed: authentication error");
-					CIPluginSDKUtils.doWait(10000);
+					CIPluginSDKUtils.doWait(30000);
 				} else if (octaneResponse.getStatus() == HttpStatus.SC_FORBIDDEN) {
 					logger.error("connection to Octane failed: authorization error");
-					CIPluginSDKUtils.doWait(10000);
+					CIPluginSDKUtils.doWait(30000);
 				} else if (octaneResponse.getStatus() == HttpStatus.SC_NOT_FOUND) {
 					logger.error("connection to Octane failed: 404, API changes? version problem?");
-					CIPluginSDKUtils.doWait(60000);
+					CIPluginSDKUtils.doWait(180000);
 				} else {
 					logger.error("unexpected response from Octane; status: " + octaneResponse.getStatus() + ", content: " + octaneResponse.getBody());
 					CIPluginSDKUtils.doWait(10000);

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsServiceImpl.java
@@ -191,6 +191,9 @@ final class EventsServiceImpl implements EventsService {
 		}
 		if (octaneResponse.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || octaneResponse.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
 			throw new TemporaryException("PUT events failed with status " + octaneResponse.getStatus());
+		} else if (octaneResponse.getStatus() == HttpStatus.SC_UNAUTHORIZED || octaneResponse.getStatus() == HttpStatus.SC_FORBIDDEN) {
+			CIPluginSDKUtils.doWait(30000);
+			throw new PermanentException("PUT events failed with status " + octaneResponse.getStatus());
 		} else if (octaneResponse.getStatus() != HttpStatus.SC_OK) {
 			throw new PermanentException("PUT events failed with status " + octaneResponse.getStatus());
 		}

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsServiceImpl.java
@@ -202,6 +202,9 @@ final class LogsServiceImpl implements LogsService {
 			response = restService.obtainOctaneRestClient().execute(preflightRequest);
 			if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
 				throw new TemporaryException("preflight request failed with status " + response.getStatus());
+			} else if (response.getStatus() == HttpStatus.SC_UNAUTHORIZED || response.getStatus() == HttpStatus.SC_FORBIDDEN) {
+				CIPluginSDKUtils.doWait(30000);
+				throw new PermanentException("preflight request failed with status " + response.getStatus());
 			} else if (response.getStatus() != HttpStatus.SC_OK && response.getStatus() != HttpStatus.SC_NO_CONTENT) {
 				throw new PermanentException("preflight request failed with status " + response.getStatus());
 			}

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
@@ -107,6 +107,9 @@ final class TestsServiceImpl implements TestsService {
 				return String.valueOf(true).equals(response.getBody());
 			} else if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
 				throw new TemporaryException("preflight request failed with status " + response.getStatus());
+			} else if (response.getStatus() == HttpStatus.SC_UNAUTHORIZED || response.getStatus() == HttpStatus.SC_FORBIDDEN) {
+				CIPluginSDKUtils.doWait(30000);
+				throw new PermanentException("preflight request failed with status " + response.getStatus());
 			} else {
 				throw new PermanentException("preflight request failed with status " + response.getStatus());
 			}


### PR DESCRIPTION
…g delay in tests/logs/events in the same case to chill the plugin down when wrong credentials used

More info: when wrong credentials used, plugin correctly detects this as Permanent error. BUT on permanent error there is no delay between the previous send of data and the next one.
Only a bridge was protected in this case.

So:
- raised the sleeping time for bridge for such a case
- added sleeping time for the main interop services (events, tests, logs)