### PR TITLE
update external link only if we need to the update the external link

### DIFF
--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/FODValuesConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/FODValuesConverter.java
@@ -68,7 +68,9 @@ public class FODValuesConverter {
         setStatus(entity, vulnerability.status);
         setSeverity(entity, vulnerability.severity);
         entity.setRemoteId(vulnerability.getRemoteId());
-        setExternalLink(vulnerability, entity);
+        if(vulnerabilityAllData != null) {
+            setExternalLink(vulnerability, entity);
+        }
         setAssignedUser(entity, vulnerability.assignedUser);
         setAnalysis(entity, vulnerability);
         entity.setRemoteTag(remoteTag);


### PR DESCRIPTION
Enables working with older versions of octane.