### PR TITLE
reduce sending frequency of requests

### DIFF
--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageServiceImpl.java
@@ -56,6 +56,7 @@ class CoverageServiceImpl implements CoverageService {
 
 	private int TEMPORARY_ERROR_BREATHE_INTERVAL = 15000;
 	private int LIST_EMPTY_INTERVAL = 3000;
+	private int REGULAR_CYCLE_PAUSE = 250;
 
 	CoverageServiceImpl(OctaneSDK.SDKServicesConfigurer configurer, QueueingService queueingService, RestService restService) {
 		if (configurer == null || configurer.pluginServices == null || configurer.octaneConfiguration == null) {
@@ -85,6 +86,7 @@ class CoverageServiceImpl implements CoverageService {
 	// infallible everlasting background worker
 	private void worker() {
 		while (!coveragePushExecutor.isShutdown()) {
+			CIPluginSDKUtils.doWait(REGULAR_CYCLE_PAUSE);
 			if (coveragePushQueue.size() == 0) {
 				CIPluginSDKUtils.doBreakableWait(LIST_EMPTY_INTERVAL, NO_COVERAGES_MONITOR);
 				continue;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsServiceImpl.java
@@ -54,6 +54,7 @@ final class LogsServiceImpl implements LogsService {
 
 	private int TEMPORARY_ERROR_BREATHE_INTERVAL = 15000;
 	private int LIST_EMPTY_INTERVAL = 3000;
+	private int REGULAR_CYCLE_PAUSE = 250;
 
 	LogsServiceImpl(OctaneSDK.SDKServicesConfigurer configurer, QueueingService queueingService, RestService restService) {
 		if (configurer == null || configurer.pluginServices == null || configurer.octaneConfiguration == null) {
@@ -103,6 +104,8 @@ final class LogsServiceImpl implements LogsService {
 	//  infallible everlasting background worker
 	private void worker() {
 		while (!logsPushExecutor.isShutdown()) {
+			CIPluginSDKUtils.doWait(REGULAR_CYCLE_PAUSE);
+
 			if (buildLogsQueue.size() == 0) {
 				CIPluginSDKUtils.doBreakableWait(LIST_EMPTY_INTERVAL, NO_LOGS_MONITOR);
 				continue;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/sonar/SonarServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/sonar/SonarServiceImpl.java
@@ -74,6 +74,7 @@ public class SonarServiceImpl implements SonarService {
 
 	private int TEMPORARY_ERROR_BREATHE_INTERVAL = 15000;
 	private int LIST_EMPTY_INTERVAL = 3000;
+	private int REGULAR_CYCLE_PAUSE = 250;
 
 	public SonarServiceImpl(OctaneSDK.SDKServicesConfigurer configurer, QueueingService queueingService, CoverageService coverageService) {
 		if (configurer == null || configurer.pluginServices == null || configurer.octaneConfiguration == null) {
@@ -103,6 +104,7 @@ public class SonarServiceImpl implements SonarService {
 	// infallible everlasting background worker
 	private void worker() {
 		while (!sonarIntegrationExecutor.isShutdown()) {
+			CIPluginSDKUtils.doWait(REGULAR_CYCLE_PAUSE);
 			if (sonarIntegrationQueue.size() == 0) {
 				CIPluginSDKUtils.doBreakableWait(LIST_EMPTY_INTERVAL, NO_SONAR_COVERAGE_ITEMS_MONITOR);
 				continue;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
@@ -62,6 +62,7 @@ final class TestsServiceImpl implements TestsService {
 
 	private int TEMPORARY_ERROR_BREATHE_INTERVAL = 10000;
 	private int LIST_EMPTY_INTERVAL = 3000;
+	private int REGULAR_CYCLE_PAUSE = 250;
 
 	TestsServiceImpl(OctaneSDK.SDKServicesConfigurer configurer, QueueingService queueingService, RestService restService) {
 		if (configurer == null) {
@@ -193,6 +194,7 @@ final class TestsServiceImpl implements TestsService {
 	//  infallible everlasting background worker
 	private void worker() {
 		while (!testsPushExecutor.isShutdown()) {
+			CIPluginSDKUtils.doWait(REGULAR_CYCLE_PAUSE);
 			if (testResultsQueue.size() == 0) {
 				CIPluginSDKUtils.doBreakableWait(LIST_EMPTY_INTERVAL, NO_TEST_RESULTS_MONITOR);
 				continue;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
@@ -147,8 +147,8 @@ public class VulnerabilitiesServiceImpl implements VulnerabilitiesService {
 	//  TODO: consider moving the overall queue managing logic to some generic location
 	//  infallible everlasting background worker
 	private void worker() {
-		CIPluginSDKUtils.doWait(REGULAR_CYCLE_PAUSE);
 		while (!vulnerabilitiesProcessingExecutor.isShutdown()) {
+			CIPluginSDKUtils.doWait(REGULAR_CYCLE_PAUSE);
 			if (vulnerabilitiesQueue.size() == 0) {
 				CIPluginSDKUtils.doBreakableWait(LIST_EMPTY_INTERVAL, NO_VULNERABILITIES_RESULTS_MONITOR);
 				continue;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
@@ -65,6 +65,8 @@ public class VulnerabilitiesServiceImpl implements VulnerabilitiesService {
 
 	private int TEMPORARY_ERROR_BREATHE_INTERVAL = 10000;
 	private int LIST_EMPTY_INTERVAL = 10000;
+	private int REGULAR_CYCLE_PAUSE = 250;
+
 	private int SKIP_QUEUE_ITEM_INTERVAL = 5000;
 	private Long DEFAULT_TIME_OUT_FOR_QUEUE_ITEM = 12 * 60 * 60 * 1000L;
 	private CompletableFuture<Boolean> workerExited;
@@ -145,6 +147,7 @@ public class VulnerabilitiesServiceImpl implements VulnerabilitiesService {
 	//  TODO: consider moving the overall queue managing logic to some generic location
 	//  infallible everlasting background worker
 	private void worker() {
+		CIPluginSDKUtils.doWait(REGULAR_CYCLE_PAUSE);
 		while (!vulnerabilitiesProcessingExecutor.isShutdown()) {
 			if (vulnerabilitiesQueue.size() == 0) {
 				CIPluginSDKUtils.doBreakableWait(LIST_EMPTY_INTERVAL, NO_VULNERABILITIES_RESULTS_MONITOR);


### PR DESCRIPTION
if Octane was down for some time, many events/logs/data cumulated in queues and after Octane is up - everything is sent to Octane. Need to reduce sending frequency by sleeping between requests.