### PR TITLE
defect #941010 : [SDK converter] When gherkin test path contains spac…

### DIFF
--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/CucumberJVMConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/CucumberJVMConverter.java
@@ -21,7 +21,9 @@ public class CucumberJVMConverter extends TestsToRunConverter {
             String featureFilePath = getFeatureFilePath(testData);
             if (featureFilePath != null && !featureFilePath.isEmpty()) {
                 sb.append(classJoiner);
+                sb.append("'");
                 sb.append(featureFilePath);
+                sb.append("'");
                 classJoiner = " ";
             }
 


### PR DESCRIPTION
…es, test runner cannot run.