### PR TITLE
cpe#2481063 automation tools plugin not writing data in nga.log

### DIFF
--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logging/CommonLoggerContextUtil.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logging/CommonLoggerContextUtil.java
@@ -18,6 +18,9 @@ public class CommonLoggerContextUtil {
         if (allowedStorage != null && (allowedStorage.isDirectory() || !allowedStorage.exists())) {
             synchronized (INIT_LOCKER) {
                 if (commonLoggerContext != null) {
+                    if (!commonLoggerContext.isStarted()) {
+                        commonLoggerContext.start();
+                    }
                     return commonLoggerContext;
                 }
                 commonLoggerContext = LoggerContext.getContext(false);


### PR DESCRIPTION
-When removing all the clients, the nga logs are stopping. When adding a new client, the logs should start again.