### PR TITLE
copyright update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,8 @@
-Copyright 2017-2023 Open Text
+Copyright 2017-${copyright.end.year} Open Text
 
+OpenText is a trademark of Open Text.
 The only warranties for products and services of Open Text and
-its affiliates and licensors (“Open Text”) are as may be set forth
+its affiliates and licensors ("Open Text") are as may be set forth
 in the express warranty statements accompanying such products and services.
 Nothing herein should be construed as constituting an additional warranty.
 Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/pom.xml
+++ b/integrations-dto/pom.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/integrations-dto/pom.xml
+++ b/integrations-dto/pom.xml
@@ -39,7 +39,7 @@
 	<parent>
 		<artifactId>java-sdk</artifactId>
 		<groupId>com.hpe.adm.octane.ciplugins</groupId>
-		<version>2.24.3-SNAPSHOT</version>
+		<version>2.24.4-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>integrations-dto</artifactId>

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOBase.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOBase.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto;
 
 /**

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOFactory.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOFactory.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOInternalProviderBase.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/DTOInternalProviderBase.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto;
 
 import java.util.LinkedHashMap;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/causes/CIEventCause.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/causes/CIEventCause.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.causes;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/causes/CIEventCauseType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/causes/CIEventCauseType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.causes;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/causes/impl/CIEventCauseImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/causes/impl/CIEventCauseImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.causes.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/causes/impl/DTOCausesProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/causes/impl/DTOCausesProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.causes.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/configuration/CIProxyConfiguration.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/configuration/CIProxyConfiguration.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.configuration;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/configuration/impl/CIProxyConfigurationImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/configuration/impl/CIProxyConfigurationImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.configuration.impl;
 
 import com.hp.octane.integrations.dto.configuration.CIProxyConfiguration;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/configuration/impl/DTOConfigsProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/configuration/impl/DTOConfigsProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.configuration.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/HttpMethod.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/HttpMethod.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/OctaneRequest.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/OctaneRequest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/OctaneResponse.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/OctaneResponse.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/OctaneResultAbridged.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/OctaneResultAbridged.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/OctaneTaskAbridged.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/OctaneTaskAbridged.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/TaskProcessingErrorBody.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/TaskProcessingErrorBody.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/DTOConnectivityProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/DTOConnectivityProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/OctaneRequestImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/OctaneRequestImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/OctaneResponseImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/OctaneResponseImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/OctaneResultAbridgedImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/OctaneResultAbridgedImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/OctaneTaskAbridgedImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/OctaneTaskAbridgedImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/TaskProcessingErrorBodyImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/connectivity/impl/TaskProcessingErrorBodyImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/BuildCoverage.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/BuildCoverage.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.coverage;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/CoverageReportType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/CoverageReportType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/FileCoverage.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/FileCoverage.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.coverage;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/LineCoverage.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/LineCoverage.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.coverage;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/TestCoverage.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/TestCoverage.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.coverage;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/BuildCoverageImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/BuildCoverageImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.coverage.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/DTOCoverageProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/DTOCoverageProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.coverage.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/FileCoverageImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/FileCoverageImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.coverage.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/LineCoverageImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/LineCoverageImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.coverage.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/TestCoverageImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/coverage/impl/TestCoverageImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.coverage.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/Entity.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/Entity.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.entities;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/EntityConstants.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/EntityConstants.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/EntityList.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/EntityList.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.entities;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/OctaneBulkExceptionData.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/OctaneBulkExceptionData.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.entities;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/OctaneRestExceptionData.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/OctaneRestExceptionData.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.entities;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/ResponseEntityList.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/ResponseEntityList.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.entities;
 
 /**

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/DTOEntityProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/DTOEntityProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.entities.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/EntityImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/EntityImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/EntityListImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/EntityListImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/OctaneBulkExceptionDataImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/OctaneBulkExceptionDataImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/OctaneRestExceptionDataImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/OctaneRestExceptionDataImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/ResponseEntityListImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/entities/impl/ResponseEntityListImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/CIEvent.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/CIEvent.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.events;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/CIEventType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/CIEventType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.events;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/CIEventsList.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/CIEventsList.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.events;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/ItemType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/ItemType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.events;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/MultiBranchType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/MultiBranchType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.events;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/PhaseType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/PhaseType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.events;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/impl/CIEventImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/impl/CIEventImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.events.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/impl/CIEventsListImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/impl/CIEventsListImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.events.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/impl/DTOEventsProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/events/impl/DTOEventsProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.events.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/CredentialsInfo.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/CredentialsInfo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.executor;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/DiscoveryInfo.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/DiscoveryInfo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.executor;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/TestConnectivityInfo.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/TestConnectivityInfo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.executor;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/CredentialsInfoImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/CredentialsInfoImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.executor.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/DTOExecutorsProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/DTOExecutorsProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.executor.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/DiscoveryInfoImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/DiscoveryInfoImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.executor.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/TestConnectivityInfoImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/TestConnectivityInfoImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.executor.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/TestingToolType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/executor/impl/TestingToolType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.executor.impl;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIBranchesList.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIBranchesList.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIBuildStatusInfo.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIBuildStatusInfo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIJobsList.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIJobsList.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIPluginInfo.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIPluginInfo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIPluginSDKInfo.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIPluginSDKInfo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIProviderSummaryInfo.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIProviderSummaryInfo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIServerInfo.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIServerInfo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIServerTypes.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/CIServerTypes.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/ListItem.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/ListItem.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/MbtData.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/MbtData.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/MbtDataTable.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/MbtDataTable.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/MbtUnit.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/MbtUnit.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/MbtUnitParameter.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/MbtUnitParameter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/OctaneConnectivityStatus.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/OctaneConnectivityStatus.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/SonarInfo.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/SonarInfo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/Taxonomy.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/Taxonomy.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIBranchesListImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIBranchesListImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIBuildStatusInfoImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIBuildStatusInfoImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIJobsListImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIJobsListImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIPluginInfoImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIPluginInfoImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIPluginSDKInfoImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIPluginSDKInfoImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIProviderSummaryInfoImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIProviderSummaryInfoImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIServerInfoImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/CIServerInfoImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/DTOGeneralProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/DTOGeneralProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/ListItemImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/ListItemImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/MbtDataImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/MbtDataImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/MbtDataTableImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/MbtDataTableImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/MbtUnitImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/MbtUnitImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/MbtUnitParameterImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/MbtUnitParameterImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/OctaneConnectivityStatusImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/OctaneConnectivityStatusImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/SonarInfoImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/SonarInfoImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/TaxonomyImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/general/impl/TaxonomyImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/CIParameter.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/CIParameter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.parameters;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/CIParameterType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/CIParameterType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.parameters;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/CIParameters.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/CIParameters.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.parameters;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/impl/CIParameterImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/impl/CIParameterImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.parameters.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/impl/CIParametersImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/impl/CIParametersImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.parameters.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/impl/DTOParametersProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/parameters/impl/DTOParametersProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.parameters.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/PipelineContext.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/PipelineContext.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.pipelines;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/PipelineContextList.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/PipelineContextList.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.pipelines;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/PipelineNode.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/PipelineNode.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.pipelines;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/PipelinePhase.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/PipelinePhase.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.pipelines;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/DTOPipelinesProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/DTOPipelinesProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.pipelines.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/PipelineContextImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/PipelineContextImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.pipelines.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/PipelineContextListImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/PipelineContextListImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.pipelines.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/PipelineNodeImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/PipelineNodeImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.pipelines.impl;
 
 import com.hp.octane.integrations.dto.events.MultiBranchType;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/PipelinePhaseImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/pipelines/impl/PipelinePhaseImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.pipelines.impl;
 
 import com.hp.octane.integrations.dto.pipelines.PipelineNode;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/Branch.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/Branch.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/PullRequest.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/PullRequest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMChange.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMChange.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMCommit.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMCommit.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMData.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMData.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMFileBlame.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMFileBlame.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMRepository.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMRepository.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMRepositoryLinks.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMRepositoryLinks.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/SCMType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/BranchImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/BranchImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/DTOSCMProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/DTOSCMProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/LineRange.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/LineRange.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/PullRequestImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/PullRequestImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/RevisionsMap.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/RevisionsMap.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMChangeImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMChangeImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMChangeType.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMChangeType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm.impl;
 
 

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMCommitImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMCommitImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMDataImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMDataImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMFileBlameImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMFileBlameImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMRepositoryImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMRepositoryImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMRepositoryLinksImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/scm/impl/SCMRepositoryLinksImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.scm.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/FodServerConfiguration.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/FodServerConfiguration.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/OctaneIssue.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/OctaneIssue.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/SSCProjectConfiguration.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/SSCProjectConfiguration.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.securityscans;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/impl/DTOSecurityContextProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/impl/DTOSecurityContextProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.securityscans.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/impl/FodServerConfigurationImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/impl/FodServerConfigurationImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/impl/OctaneIssueImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/impl/OctaneIssueImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/impl/SSCProjectConfigurationImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/securityscans/impl/SSCProjectConfigurationImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.securityscans.impl;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/snapshots/CIBuildResult.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/snapshots/CIBuildResult.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.snapshots;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/snapshots/CIBuildStatus.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/snapshots/CIBuildStatus.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.snapshots;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/BuildContext.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/BuildContext.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/Property.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/Property.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestCase.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestCase.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestCaseFailure.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestCaseFailure.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestField.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestField.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestRun.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestRun.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestRunError.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestRunError.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestRunResult.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestRunResult.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestSuite.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestSuite.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestsResult.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/TestsResult.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/BuildContextImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/BuildContextImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/DTOJUnitTestsProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/DTOJUnitTestsProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/DTOTestsProvider.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/DTOTestsProvider.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.hp.octane.integrations.dto.DTOBase;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/PropertyImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/PropertyImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestCaseFailureImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestCaseFailureImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestCaseImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestCaseImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestFieldImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestFieldImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestRunErrorImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestRunErrorImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestRunImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestRunImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestSuiteImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestSuiteImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestsResultImpl.java
+++ b/integrations-dto/src/main/java/com/hp/octane/integrations/dto/tests/impl/TestsResultImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-dto/src/test/java/com/hp/octane/integrations/dto/DTOFactoryTest.java
+++ b/integrations-dto/src/test/java/com/hp/octane/integrations/dto/DTOFactoryTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto;
 
 import com.hp.octane.integrations.dto.general.CIServerTypes;

--- a/integrations-dto/src/test/java/com/hp/octane/integrations/dto/connectivity/OctaneRequestTest.java
+++ b/integrations-dto/src/test/java/com/hp/octane/integrations/dto/connectivity/OctaneRequestTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-dto/src/test/java/com/hp/octane/integrations/dto/connectivity/OctaneTaskAbridgedTest.java
+++ b/integrations-dto/src/test/java/com/hp/octane/integrations/dto/connectivity/OctaneTaskAbridgedTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.connectivity;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-dto/src/test/java/com/hp/octane/integrations/dto/executor/ExecutorDTOTests.java
+++ b/integrations-dto/src/test/java/com/hp/octane/integrations/dto/executor/ExecutorDTOTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.executor;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-dto/src/test/java/com/hp/octane/integrations/dto/general/EntityDTOTests.java
+++ b/integrations-dto/src/test/java/com/hp/octane/integrations/dto/general/EntityDTOTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.general;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-dto/src/test/java/com/hp/octane/integrations/dto/tests/TestsDTOsTest.java
+++ b/integrations-dto/src/test/java/com/hp/octane/integrations/dto/tests/TestsDTOsTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto.tests;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-sdk/pom.xml
+++ b/integrations-sdk/pom.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>

--- a/integrations-sdk/pom.xml
+++ b/integrations-sdk/pom.xml
@@ -37,7 +37,7 @@
 	<parent>
 		<artifactId>java-sdk</artifactId>
 		<groupId>com.hpe.adm.octane.ciplugins</groupId>
-		<version>2.24.3-SNAPSHOT</version>
+		<version>2.24.4-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/CIPluginServices.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/CIPluginServices.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations;
 
 import com.hp.octane.integrations.dto.configuration.CIProxyConfiguration;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClient.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClient.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations;
 
 import com.hp.octane.integrations.services.HasMetrics;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneClientImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations;
 
 import com.hp.octane.integrations.dto.general.OctaneConnectivityStatus;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneConfiguration.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneConfiguration.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneSDK.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/OctaneSDK.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations;
 
 import com.hp.octane.integrations.dto.entities.Entity;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/ConfigurationException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/ConfigurationException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/ErrorCodeBasedException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/ErrorCodeBasedException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneBulkException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneBulkException.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.exceptions;
 
 import com.hp.octane.integrations.dto.entities.OctaneBulkExceptionData;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneConnectivityException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneConnectivityException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class OctaneConnectivityException extends ErrorCodeBasedException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneRestException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneRestException.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.exceptions;
 
 import com.hp.octane.integrations.dto.entities.OctaneRestExceptionData;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneSDKGeneralException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneSDKGeneralException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class OctaneSDKGeneralException extends RuntimeException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneValidationException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/OctaneValidationException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class OctaneValidationException extends RuntimeException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/PermanentException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/PermanentException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class PermanentException extends RuntimeException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/PermissionException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/PermissionException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class PermissionException extends ErrorCodeBasedException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/RequestTimeoutException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/RequestTimeoutException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class RequestTimeoutException extends RuntimeException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/ResourceNotFoundException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/ResourceNotFoundException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class ResourceNotFoundException extends RuntimeException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/SPIMethodNotImplementedException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/SPIMethodNotImplementedException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class SPIMethodNotImplementedException extends RuntimeException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/SonarIntegrationException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/SonarIntegrationException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class SonarIntegrationException extends Exception {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/TemporaryException.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/exceptions/TemporaryException.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exceptions;
 
 public class TemporaryException extends RuntimeException {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestToRunData.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestToRunData.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestToRunDataCollection.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestToRunDataCollection.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.executor;
 
 import java.util.ArrayList;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestsToRunConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestsToRunConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestsToRunConverterResult.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestsToRunConverterResult.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestsToRunConvertersFactory.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestsToRunConvertersFactory.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor;
 
 import com.hp.octane.integrations.executor.converters.*;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestsToRunFramework.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/TestsToRunFramework.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/BDDConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/BDDConverter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.executor.converters;
 
 import com.hp.octane.integrations.executor.TestToRunData;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/CucumberJVMConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/CucumberJVMConverter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.executor.converters;
 
 import com.hp.octane.integrations.executor.TestToRunData;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/CustomConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/CustomConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor.converters;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/GradleConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/GradleConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor.converters;
 
 /*

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/JBehaveConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/JBehaveConverter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.executor.converters;
 
 import com.hp.octane.integrations.executor.TestToRunData;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MavenSurefireAndFailsafeConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MavenSurefireAndFailsafeConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor.converters;
 
 import com.hp.octane.integrations.executor.TestToRunData;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MbtCodelessTest.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MbtCodelessTest.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.executor.converters;
 
 import com.hp.octane.integrations.dto.executor.impl.TestingToolType;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MbtCodelessUnit.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MbtCodelessUnit.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.executor.converters;
 
 import com.hp.octane.integrations.dto.general.MbtUnitParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MbtTest.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MbtTest.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.executor.converters;
 
 import com.hp.octane.integrations.dto.executor.impl.TestingToolType;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MbtUftTest.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MbtUftTest.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.executor.converters;
 
 import com.hp.octane.integrations.dto.executor.impl.TestingToolType;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MfMBTConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MfMBTConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor.converters;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MfUftConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/MfUftConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor.converters;
 
 import com.hp.octane.integrations.OctaneClient;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/ProtractorConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/executor/converters/ProtractorConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor.converters;
 
 /*

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/octaneExecution/ExecutionMode.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/octaneExecution/ExecutionMode.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/ClosableService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/ClosableService.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services;
 
 public interface ClosableService {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/HasMetrics.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/HasMetrics.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services;
 
 import java.util.Map;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/HasQueueService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/HasQueueService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services;
 
 /**

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/SupportsConsoleLog.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/SupportsConsoleLog.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services;
 
 public interface SupportsConsoleLog {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/WorkerPreflight.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/WorkerPreflight.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services;
 
 import com.hp.octane.integrations.services.configuration.ConfigurationService;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.bridge;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.bridge;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/ServiceState.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/ServiceState.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.bridge;
 
 public enum ServiceState {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configuration/ConfigurationService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configuration/ConfigurationService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.configuration;
 
 import com.hp.octane.integrations.OctaneConfiguration;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configuration/ConfigurationServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configuration/ConfigurationServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/AddGlobalParameterToTestsParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/AddGlobalParameterToTestsParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/EncodeCiJobBase64Parameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/EncodeCiJobBase64Parameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/FortifySSCFetchTimeoutParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/FortifySSCFetchTimeoutParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/FortifySSCTokenParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/FortifySSCTokenParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/JobListCacheAllowedParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/JobListCacheAllowedParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/LogEventsParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/LogEventsParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/OctaneRootsCacheAllowedParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/OctaneRootsCacheAllowedParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/SCMRestAPIParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/SCMRestAPIParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/SendEventsInBulkParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/SendEventsInBulkParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/UftTestConnectionDisabledParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/UftTestConnectionDisabledParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/UftTestRunnerFolderParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/UftTestRunnerFolderParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/UftTestsDeepRenameParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/UftTestsDeepRenameParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters;
 
 import com.hp.octane.integrations.services.configurationparameters.factory.ConfigurationParameter;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/factory/ConfigurationParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/factory/ConfigurationParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters.factory;
 
 public interface ConfigurationParameter {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/factory/ConfigurationParameterFactory.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/configurationparameters/factory/ConfigurationParameterFactory.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.configurationparameters.factory;
 
 import com.hp.octane.integrations.OctaneConfiguration;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.coverage;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.coverage;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/entities/EntitiesService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/entities/EntitiesService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.entities;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/entities/EntitiesServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/entities/EntitiesServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.entities;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/entities/QueryHelper.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/entities/QueryHelper.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.entities;
 
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.events;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.events;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logging/CommonLoggerContextUtil.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logging/CommonLoggerContextUtil.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.logging;
 
 import org.apache.logging.log4j.core.LoggerContext;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logging/LoggingService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logging/LoggingService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.logging;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logging/LoggingServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logging/LoggingServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.logging;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.logs;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.logs;
 
 import com.hp.octane.integrations.OctaneConfiguration;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pipelines/PipelineContextService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pipelines/PipelineContextService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pipelines;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pipelines/PipelineContextServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pipelines/PipelineContextServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pipelines;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/BranchSyncResult.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/BranchSyncResult.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.pullrequestsandbranches;
 
 import com.hp.octane.integrations.dto.scm.Branch;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/PullRequestAndBranchService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/PullRequestAndBranchService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/PullRequestAndBranchServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/PullRequestAndBranchServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/BitbucketServerFetchHandler.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/BitbucketServerFetchHandler.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/JsonConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/JsonConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Branch.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Branch.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/BranchMetadata.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/BranchMetadata.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/BranchMetadataAheadBehind.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/BranchMetadataAheadBehind.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/BranchMetadataLatestCommit.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/BranchMetadataLatestCommit.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Commit.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Commit.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/CommitParent.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/CommitParent.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Entity.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Entity.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/EntityCollection.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/EntityCollection.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/ErrorDetails.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/ErrorDetails.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Link.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Link.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Links.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Links.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Project.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Project.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/PullRequest.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/PullRequest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Ref.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Ref.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Repository.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/Repository.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/RequestErrors.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/RequestErrors.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/SupportUpdatedTime.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/SupportUpdatedTime.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 public interface SupportUpdatedTime {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/User.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/User.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/UserDetails.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/bitbucketserver/pojo/UserDetails.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/BranchFetchParameters.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/BranchFetchParameters.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.factory;
 
 import java.io.Serializable;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/CommitUserIdPicker.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/CommitUserIdPicker.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.pullrequestsandbranches.factory;
 
 public interface CommitUserIdPicker {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/FetchFactory.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/FetchFactory.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.factory;
 
 import com.hp.octane.integrations.services.pullrequestsandbranches.bitbucketserver.BitbucketServerFetchHandler;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/FetchHandler.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/FetchHandler.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.factory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/FetchUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/FetchUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.factory;
 
 import com.hp.octane.integrations.utils.SdkStringUtils;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/PullRequestFetchParameters.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/PullRequestFetchParameters.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.factory;
 
 import java.io.Serializable;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/RepoTemplates.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/factory/RepoTemplates.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.pullrequestsandbranches.factory;
 
 public class RepoTemplates {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/GithubCloudFetchHandler.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/GithubCloudFetchHandler.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github;
 
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/GithubServerFetchHandler.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/GithubServerFetchHandler.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github;
 
 import com.hp.octane.integrations.services.pullrequestsandbranches.rest.authentication.AuthenticationStrategy;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/GithubV3FetchHandler.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/GithubV3FetchHandler.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.hp.octane.integrations.services.pullrequestsandbranches.github;
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/JsonConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/JsonConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Branch.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Branch.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Commit.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Commit.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/CommitDetails.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/CommitDetails.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/CommitParent.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/CommitParent.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/CommitUser.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/CommitUser.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Compare.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Compare.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Entity.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Entity.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/PullRequest.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/PullRequest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/PullRequestRepo.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/PullRequestRepo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/PullRequestUser.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/PullRequestUser.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/RateLimitationInfo.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/RateLimitationInfo.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 public class RateLimitationInfo {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Repo.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/Repo.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/RequestError.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/RequestError.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/SupportUpdatedTime.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/SupportUpdatedTime.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 public interface SupportUpdatedTime {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/User.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/github/pojo/User.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.github.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/GitlabServerFetchHandler.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/GitlabServerFetchHandler.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/JsonConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/JsonConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.gitlab;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/Entity.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/Entity.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.gitlab.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/EntityCollection.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/EntityCollection.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.gitlab.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/ErrorDetails.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/ErrorDetails.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.gitlab.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/Repository.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/Repository.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.gitlab.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/RequestErrors.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/gitlab/pojo/RequestErrors.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.gitlab.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/GeneralRestClient.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/GeneralRestClient.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.rest;
 
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/ScmTool.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/ScmTool.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.rest;
 
 import com.hp.octane.integrations.utils.SdkStringUtils;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/authentication/AuthenticationStrategy.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/authentication/AuthenticationStrategy.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.rest.authentication;
 
 import org.apache.http.HttpResponse;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/authentication/BasicAuthenticationStrategy.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/authentication/BasicAuthenticationStrategy.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.rest.authentication;
 
 import org.apache.http.HttpHeaders;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/authentication/NoCredentialsStrategy.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/authentication/NoCredentialsStrategy.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.rest.authentication;
 
 public class NoCredentialsStrategy extends AuthenticationStrategy {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/authentication/PATStrategy.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/pullrequestsandbranches/rest/authentication/PATStrategy.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches.rest.authentication;
 
 import org.apache.http.HttpHeaders;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/queueing/QueueingService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/queueing/QueueingService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.queueing;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/queueing/QueueingServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/queueing/QueueingServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.queueing;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/OctaneRestClient.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/OctaneRestClient.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.rest;
 
 import com.hp.octane.integrations.OctaneConfiguration;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/OctaneRestClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/OctaneRestClientImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.rest;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/RestService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/RestService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.rest;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/RestServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/RestServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.rest;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/SSCRestClient.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/SSCRestClient.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.rest;
 
 import com.hp.octane.integrations.dto.securityscans.SSCProjectConfiguration;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/SSCRestClientImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/rest/SSCRestClientImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/scmdata/SCMDataQueueItem.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/scmdata/SCMDataQueueItem.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.scmdata;
 
 import com.hp.octane.integrations.services.queueing.QueueingService;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/scmdata/SCMDataService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/scmdata/SCMDataService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.scmdata;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/scmdata/SCMDataServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/scmdata/SCMDataServiceImpl.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.scmdata;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/sonar/SonarService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/sonar/SonarService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.sonar;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/sonar/SonarServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/sonar/SonarServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.sonar;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/sonar/SonarUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/sonar/SonarUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.sonar;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tasking/TasksProcessor.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tasking/TasksProcessor.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.tasking;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tasking/TasksProcessorImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tasking/TasksProcessorImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.tasking;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/testexecution/TestExecutionContext.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/testexecution/TestExecutionContext.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.testexecution;
 
 import com.hp.octane.integrations.dto.entities.Entity;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/testexecution/TestExecutionIdentifierType.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/testexecution/TestExecutionIdentifierType.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.testexecution;
 
 public enum TestExecutionIdentifierType {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/testexecution/TestExecutionService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/testexecution/TestExecutionService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.testexecution;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/testexecution/TestExecutionServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/testexecution/TestExecutionServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.testexecution;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.tests;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.tests;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/DateUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/DateUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ExistingIssuesInOctane.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ExistingIssuesInOctane.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/IssuesFileSerializer.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/IssuesFileSerializer.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/OctaneIssueConsts.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/OctaneIssueConsts.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/PackIssuesToOctaneUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/PackIssuesToOctaneUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/RawVulnerability.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/RawVulnerability.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ToolType.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ToolType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 public enum ToolType {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesGeneralUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesGeneralUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesQueueItem.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesQueueItem.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.services.queueing.QueueingService;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesToolService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesToolService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/FODService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/FODService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.fod;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/FODServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/FODServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/FODValuesConverter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/FODValuesConverter.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/PplnRunStatus.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/PplnRunStatus.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODConfig.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODConfig.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODConnector.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODConnector.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.fod.dto;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODConstants.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODConstants.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODEntityCollection.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODEntityCollection.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.fod.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODSource.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODSource.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FodConnectionFactory.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FodConnectionFactory.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/SecurityTool.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/SecurityTool.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/mock/FodMockSource.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/mock/FodMockSource.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/Application.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/Application.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/FODUser.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/FODUser.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/Release.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/Release.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/Scan.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/Scan.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.fod.dto.pojos;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/Vulnerability.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/Vulnerability.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/VulnerabilityAllData.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/pojos/VulnerabilityAllData.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/services/FODReleaseService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/services/FODReleaseService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.fod.dto.services;
 
 import com.hp.octane.integrations.services.vulnerabilities.fod.dto.FodConnectionFactory;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/services/FODToLocalServiceTimeSrvice.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/services/FODToLocalServiceTimeSrvice.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.fod.dto.services;
 
 import java.text.ParseException;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/services/FODUsersRestService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/services/FODUsersRestService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/services/FODVulnerabilityService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/services/FODVulnerabilityService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.fod.dto.services;
 
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/SonarToOctaneIssueUtil.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/SonarToOctaneIssueUtil.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.sonar;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/SonarVulnerabilitiesService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/SonarVulnerabilitiesService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.sonar;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/SonarVulnerabilitiesServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/SonarVulnerabilitiesServiceImpl.java
@@ -1,34 +1,34 @@
-/**
- * Copyright 2017-2023 Open Text
- * <p>
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
  * omissions contained herein. The information contained herein is subject
  * to change without notice.
- * <p>
+ *
  * Except as specifically indicated otherwise, this document contains
  * confidential information and a valid license is required for possession,
  * use or copying. If this work is provided to the U.S. Government,
  * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
  * Computer Software Documentation, and Technical Data for Commercial Items are
  * licensed to the U.S. Government under vendor's standard commercial license.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.sonar;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/dto/SonarIssue.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/dto/SonarIssue.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.sonar.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/dto/SonarRule.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/sonar/dto/SonarRule.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.sonar.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/PackSSCIssuesToSendToOctane.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/PackSSCIssuesToSendToOctane.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCHandler.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCHandler.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.ssc;
 
 import com.hp.octane.integrations.dto.securityscans.SSCProjectConfiguration;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCProjectConnector.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCProjectConnector.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.ssc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCService.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCService.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.ssc;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCServiceImpl.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.ssc;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCToOctaneIssueUtil.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/SSCToOctaneIssueUtil.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -20,7 +21,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/Artifacts.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/Artifacts.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/AuthToken.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/AuthToken.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/IssueDetails.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/IssueDetails.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities.ssc.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/Issues.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/Issues.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/ProjectVersions.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/ProjectVersions.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/Projects.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/Projects.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/SscBaseEntityArray.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/SscBaseEntityArray.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/SscBaseEntitySingle.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/ssc/dto/SscBaseEntitySingle.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/testresults/GherkinUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/testresults/GherkinUtils.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.testresults;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/testresults/GherkinXmlWritableTestResult.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/testresults/GherkinXmlWritableTestResult.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.testresults;
 
 import com.hp.octane.integrations.dto.tests.TestRunResult;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/testresults/XmlWritableTestResult.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/testresults/XmlWritableTestResult.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.testresults;
 
 import javax.xml.stream.XMLStreamException;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/DiscoveryResultDispatcher.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/DiscoveryResultDispatcher.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/DiscoveryResultPreparer.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/DiscoveryResultPreparer.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft;
 
 import com.hp.octane.integrations.services.entities.EntitiesService;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/MbtDiscoveryResultDispatcherImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/MbtDiscoveryResultDispatcherImpl.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft;
 
 import com.hp.octane.integrations.dto.entities.Entity;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/MbtDiscoveryResultPreparerImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/MbtDiscoveryResultPreparerImpl.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft;
 
 import com.hp.octane.integrations.dto.entities.Entity;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftDiscoveryResultDispatcherImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftDiscoveryResultDispatcherImpl.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft;
 
 import com.hp.octane.integrations.dto.entities.Entity;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftDiscoveryResultPreparerImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftDiscoveryResultPreparerImpl.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft;
 
 import com.hp.octane.integrations.dto.entities.Entity;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftTestDiscoveryUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftTestDiscoveryUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft;
 
 import com.hp.octane.integrations.dto.executor.impl.TestingToolType;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftTestDispatchUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/UftTestDispatchUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft;
 
 import com.hp.octane.integrations.dto.executor.impl.TestingToolType;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/AutomatedTest.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/AutomatedTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft.items;
 
 import java.io.Serializable;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/CustomLogger.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/CustomLogger.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/JobRunContext.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/JobRunContext.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft.items;
 
 public class JobRunContext {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/OctaneStatus.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/OctaneStatus.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/ScmResourceFile.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/ScmResourceFile.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft.items;
 
 import java.io.Serializable;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/SupportsMoveDetection.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/SupportsMoveDetection.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft.items;
 
 /**

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/SupportsOctaneStatus.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/SupportsOctaneStatus.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft.items;
 
 /**

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftParameterDirection.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftParameterDirection.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.items;
 
 /**

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftTestAction.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftTestAction.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft.items;
 
 import java.io.Serializable;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftTestDiscoveryResult.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftTestDiscoveryResult.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft.items;
 
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftTestParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftTestParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.items;
 
 import java.io.Serializable;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftTestType.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/items/UftTestType.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.uft.items;
 
 /**

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/UftTestResultsUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/UftTestResultsUtils.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.ufttestresults;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/Parameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/Parameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.ufttestresults.schema;
 
 import java.util.StringJoiner;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/ReportNode.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/ReportNode.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.ufttestresults.schema;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/ReportNodeData.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/ReportNodeData.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.ufttestresults.schema;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/ReportResults.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/ReportResults.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.ufttestresults.schema;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/UftResultIterationData.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/UftResultIterationData.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.ufttestresults.schema;
 
 import java.io.Serializable;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/UftResultStepData.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/UftResultStepData.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.ufttestresults.schema;
 
 import java.io.Serializable;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/UftResultStepParameter.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/uft/ufttestresults/schema/UftResultStepParameter.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.ufttestresults.schema;
 
 import java.io.Serializable;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/CIPluginSDKUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/CIPluginSDKUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/MbtDiscoveryResultHelper.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/MbtDiscoveryResultHelper.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.utils;
 
 import com.hp.octane.integrations.dto.entities.Entity;

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/OctaneUrlParser.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/OctaneUrlParser.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.utils;
 
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/SdkConstants.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/SdkConstants.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.utils;
 
 public class SdkConstants {

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/SdkStringUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/SdkStringUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.utils;
 
 import java.time.Instant;

--- a/integrations-sdk/src/main/resources/log4j2.xml
+++ b/integrations-sdk/src/main/resources/log4j2.xml
@@ -1,34 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~    Copyright 2017-2023 Open Text
- ~    
- ~    The only warranties for products and services of Open Text and
- ~    its affiliates and licensors (“Open Text”) are as may be set forth
- ~    in the express warranty statements accompanying such products and services.
- ~    Nothing herein should be construed as constituting an additional warranty.
- ~    Open Text shall not be liable for technical or editorial errors or
- ~    omissions contained herein. The information contained herein is subject
- ~    to change without notice.
- ~    
- ~    Except as specifically indicated otherwise, this document contains
- ~    confidential information and a valid license is required for possession,
- ~    use or copying. If this work is provided to the U.S. Government,
- ~    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
- ~    Computer Software Documentation, and Technical Data for Commercial Items are
- ~    licensed to the U.S. Government under vendor's standard commercial license.
- ~    
- ~    Licensed under the Apache License, Version 2.0 (the "License");
- ~    you may not use this file except in compliance with the License.
- ~    You may obtain a copy of the License at
- ~    
- ~         http://www.apache.org/licenses/LICENSE-2.0
- ~    
- ~    Unless required by applicable law or agreed to in writing, software
- ~    distributed under the License is distributed on an "AS IS" BASIS,
- ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- ~    See the License for the specific language governing permissions and
- ~    limitations under the License.
-  -->
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 
 <Configuration status="INFO">
 

--- a/integrations-sdk/src/main/resources/sdk.properties
+++ b/integrations-sdk/src/main/resources/sdk.properties
@@ -1,31 +1,34 @@
- #    Copyright 2017-2023 Open Text
- #    
- #    The only warranties for products and services of Open Text and
- #    its affiliates and licensors (“Open Text”) are as may be set forth
- #    in the express warranty statements accompanying such products and services.
- #    Nothing herein should be construed as constituting an additional warranty.
- #    Open Text shall not be liable for technical or editorial errors or
- #    omissions contained herein. The information contained herein is subject
- #    to change without notice.
- #    
- #    Except as specifically indicated otherwise, this document contains
- #    confidential information and a valid license is required for possession,
- #    use or copying. If this work is provided to the U.S. Government,
- #    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
- #    Computer Software Documentation, and Technical Data for Commercial Items are
- #    licensed to the U.S. Government under vendor's standard commercial license.
- #    
- #    Licensed under the Apache License, Version 2.0 (the "License");
- #    you may not use this file except in compliance with the License.
- #    You may obtain a copy of the License at
- #    
- #         http://www.apache.org/licenses/LICENSE-2.0
- #    
- #    Unless required by applicable law or agreed to in writing, software
- #    distributed under the License is distributed on an "AS IS" BASIS,
- #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- #    See the License for the specific language governing permissions and
- #    limitations under the License.
+#
+# Copyright 2017-2025 Open Text
+#
+# OpenText is a trademark of Open Text.
+# The only warranties for products and services of Open Text and
+# its affiliates and licensors ("Open Text") are as may be set forth
+# in the express warranty statements accompanying such products and services.
+# Nothing herein should be construed as constituting an additional warranty.
+# Open Text shall not be liable for technical or editorial errors or
+# omissions contained herein. The information contained herein is subject
+# to change without notice.
+#
+# Except as specifically indicated otherwise, this document contains
+# confidential information and a valid license is required for possession,
+# use or copying. If this work is provided to the U.S. Government,
+# consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+# Computer Software Documentation, and Technical Data for Commercial Items are
+# licensed to the U.S. Government under vendor's standard commercial license.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
  
 api.version=1
 sdk.version=${project.version}

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneConfigurationIntern.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneConfigurationIntern.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations;
 
 public class OctaneConfigurationIntern extends OctaneConfiguration {

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneConfigurationTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneConfigurationTests.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations;
 
 import org.junit.Assert;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneSDKNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneSDKNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneSDKPositiveTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneSDKPositiveTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneSDKTestConfigurationTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/OctaneSDKTestConfigurationTests.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/dto/StatusInfoTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/dto/StatusInfoTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.dto;
 
 import com.hp.octane.integrations.dto.general.CIProviderSummaryInfo;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/end2end/basic/OctaneConfigurationBasicFunctionalityTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/end2end/basic/OctaneConfigurationBasicFunctionalityTest.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.end2end.basic;
 
 import com.hp.octane.integrations.OctaneConfigurationIntern;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/end2end/basic/OctaneSDKBasicFunctionalityTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/end2end/basic/OctaneSDKBasicFunctionalityTest.java
@@ -76,7 +76,7 @@ public class OctaneSDKBasicFunctionalityTest {
 	private static final Logger logger = LogManager.getLogger(OctaneSDKBasicFunctionalityTest.class);
 	private static DTOFactory dtoFactory = DTOFactory.getInstance();
 
-	@Test(timeout = 60000)
+	@Test(timeout = 600000)
 	public void testE2EFunctional() throws ExecutionException, InterruptedException {
 		Map<String, OctaneSPEndpointSimulator> simulators = null;
 		Map<String, List<CIEventsList>> eventsCollectors = new LinkedHashMap<>();
@@ -122,7 +122,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			simulatePushCoverageAllClients();
 
 			//  validate events
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (eventsCollectors.containsKey(spIdA) && eventsCollectors.get(spIdA).stream().mapToInt(cil -> cil.getEvents().size()).sum() == 3) {
 					eventsCollectors.get(spIdA).forEach(cil -> {
 						Assert.assertNotNull(cil);
@@ -140,7 +140,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate tests
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (testResultsCollectors.containsKey(spIdA) && testResultsCollectors.get(spIdA).size() == 1) {
 					//  TODO: add deeper verification
 					return true;
@@ -150,7 +150,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate logs
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (logsCollectors.containsKey(spIdA) && logsCollectors.get(spIdA).size() == 1) {
 					//  TODO: add deeper verification
 					return true;
@@ -160,7 +160,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate coverage
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (coverageCollectors.containsKey(spIdA) && coverageCollectors.get(spIdA).size() == 2) {
 					//  TODO: add deeper verification
 					return true;
@@ -195,7 +195,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			simulatePushCoverageAllClients();
 
 			//  validate events
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (eventsCollectors.containsKey(spIdA) && eventsCollectors.get(spIdA).stream().mapToInt(cil -> cil.getEvents().size()).sum() == 3 &&
 						eventsCollectors.containsKey(spIdB) && eventsCollectors.get(spIdA).stream().mapToInt(cil -> cil.getEvents().size()).sum() == 3) {
 					//  client A
@@ -226,7 +226,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate tests
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (testResultsCollectors.containsKey(spIdA) && testResultsCollectors.get(spIdA).size() == 1 &&
 						testResultsCollectors.containsKey(spIdB) && testResultsCollectors.get(spIdB).size() == 1) {
 					//  TODO: add deeper verification
@@ -237,7 +237,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate logs
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (logsCollectors.containsKey(spIdA) && logsCollectors.get(spIdA).size() == 1 &&
 						logsCollectors.containsKey(spIdB) && logsCollectors.get(spIdB).size() == 1) {
 					//  TODO: add deeper verification
@@ -248,7 +248,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate coverages
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (coverageCollectors.containsKey(spIdA) && coverageCollectors.get(spIdA).size() == 2 &&
 						coverageCollectors.containsKey(spIdB) && coverageCollectors.get(spIdB).size() == 2) {
 					//  TODO: add deeper verification
@@ -278,7 +278,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			simulatePushCoverageAllClients();
 
 			//  validate events
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (eventsCollectors.containsKey(spIdB) && eventsCollectors.get(spIdB).stream().mapToInt(cil -> cil.getEvents().size()).sum() == 3) {
 					Assert.assertTrue(eventsCollectors.get(spIdA).isEmpty());
 					eventsCollectors.get(spIdB).forEach(cil -> {
@@ -297,7 +297,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate tests
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (testResultsCollectors.containsKey(spIdB) && testResultsCollectors.get(spIdB).size() == 1) {
 					Assert.assertTrue(testResultsCollectors.get(spIdA).isEmpty());
 					//  TODO: add deeper verification
@@ -308,7 +308,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate logs
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (logsCollectors.containsKey(spIdB) && logsCollectors.get(spIdB).size() == 1) {
 					Assert.assertTrue(logsCollectors.get(spIdA).isEmpty());
 					//  TODO: add deeper verification
@@ -319,7 +319,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate coverages
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (coverageCollectors.containsKey(spIdB) && coverageCollectors.get(spIdB).size() == 2) {
 					Assert.assertTrue(coverageCollectors.get(spIdA).isEmpty());
 					//  TODO: add deeper verification
@@ -457,7 +457,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate tests
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (testResultsCollectors.containsKey(spIdA) && testResultsCollectors.get(spIdA).size() == 1) {
 					//  TODO: add deeper verification
 					return true;
@@ -467,7 +467,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate logs
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (logsCollectors.containsKey(spIdA) && logsCollectors.get(spIdA).size() == 1) {
 					//  TODO: add deeper verification
 					return true;
@@ -477,7 +477,7 @@ public class OctaneSDKBasicFunctionalityTest {
 			});
 
 			//  validate coverage
-			GeneralTestUtils.waitAtMostFor(20000, () -> {
+			GeneralTestUtils.waitAtMostFor(10000, () -> {
 				if (coverageCollectors.containsKey(spIdA) && coverageCollectors.get(spIdA).size() == 2) {
 					//  TODO: add deeper verification
 					return true;
@@ -540,7 +540,8 @@ public class OctaneSDKBasicFunctionalityTest {
 					//  [YG] in the future we'll remove OLD API and this validation should be done differently
 					request.mergeQueryParameters("", request.getQueryString());
 					Assert.assertEquals(request.getQueryParameters().getString("instance-id"), testsResult.getBuildContext().getServerId());
-					Assert.assertEquals(request.getQueryParameters().getString("job-ci-id"), testsResult.getBuildContext().getJobId());
+					Assert.assertTrue(request.getQueryParameters().getString("job-ci-id").equals(CIPluginSDKUtils.urlEncodeBase64(testsResult.getBuildContext().getJobId())) ||
+									  request.getQueryParameters().getString("job-ci-id").equals(testsResult.getBuildContext().getJobId()));
 					Assert.assertEquals(request.getQueryParameters().getString("build-ci-id"), testsResult.getBuildContext().getBuildId());
 					testResultsCollectors
 							.computeIfAbsent(spID, sp -> new LinkedList<>())

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/end2end/basic/OctaneSDKBasicFunctionalityTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/end2end/basic/OctaneSDKBasicFunctionalityTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.end2end.basic;
 
 import com.hp.octane.integrations.OctaneClient;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/end2end/basic/PluginServicesBasicFunctionalityTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/end2end/basic/PluginServicesBasicFunctionalityTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.end2end.basic;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/executor/CustomConverterTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/executor/CustomConverterTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor;
 
 import com.hp.octane.integrations.executor.converters.BDDConverter;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/executor/CustomConverterWithJsonTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/executor/CustomConverterWithJsonTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.executor;
 
 import com.hp.octane.integrations.executor.converters.CustomConverter;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/executor/TestsToRunConverterTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/executor/TestsToRunConverterTest.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.executor;
 
 import org.junit.Assert;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/exported/tests/SPIProvisioningTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/exported/tests/SPIProvisioningTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.exported.tests;
 
 import org.junit.Test;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/bridge/BridgeServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/bridge/BridgeServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.bridge;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/configuration/ConfigurationServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/configuration/ConfigurationServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.configuration;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/coverage/CoverageServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/coverage/CoverageServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.coverage;
 
 import com.hp.octane.integrations.*;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/entities/EntitiesServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/entities/EntitiesServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.entities;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/events/EventsServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/events/EventsServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.events;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/logging/LoggingNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/logging/LoggingNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.logging;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/logs/LogsServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/logs/LogsServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.logs;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/pipelines/PipelineContextServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/pipelines/PipelineContextServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pipelines;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/pullrequestsandbranches/PullRequestsServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/pullrequestsandbranches/PullRequestsServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.pullrequestsandbranches;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/queueing/QueueingServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/queueing/QueueingServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.queueing;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/rest/RestServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/rest/RestServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.rest;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/scmdata/SCMDataServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/scmdata/SCMDataServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.scmdata;
 
 import com.hp.octane.integrations.*;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tasking/TaskingServiceE2ETests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tasking/TaskingServiceE2ETests.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.tasking;
 
 import com.hp.octane.integrations.OctaneClient;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tasking/TaskingServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tasking/TaskingServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.tasking;
 
 import com.hp.octane.integrations.OctaneSDK;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tasking/TaskingServiceTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tasking/TaskingServiceTests.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.tasking;
 
 import com.hp.octane.integrations.OctaneClient;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tasking/TaskingTestPluginServicesTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tasking/TaskingTestPluginServicesTest.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.tasking;
 
 import com.hp.octane.integrations.CIPluginServices;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tests/TestsServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tests/TestsServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.tests;
 
 import com.hp.octane.integrations.OctaneClient;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tests/TestsServicePluginServicesTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/tests/TestsServicePluginServicesTest.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.tests;
 
 import com.hp.octane.integrations.CIPluginServices;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/ExistingIssuesInOctaneTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/ExistingIssuesInOctaneTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.OctaneConfiguration;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/ExpectedPushToOctane.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/ExpectedPushToOctane.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/IssuesValidate.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/IssuesValidate.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/OctaneInput.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/OctaneInput.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import java.util.ArrayList;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/PackIssuesToSendToOctaneTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/PackIssuesToSendToOctaneTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.dto.entities.Entity;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCHandlerTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCHandlerTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.dto.securityscans.SSCProjectConfiguration;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCInput.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCInput.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCIntegrationTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCIntegrationTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.OctaneClient;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCProjectConnectorPagingTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCProjectConnectorPagingTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.dto.securityscans.SSCProjectConfiguration;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCTestUtils.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/SSCTestUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceFunctionalityTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceFunctionalityTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.OctaneClient;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceNegativeTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceNegativeTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.*;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServicePluginServicesTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServicePluginServicesTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.services.vulnerabilities;
 
 import com.hp.octane.integrations.CIPluginServices;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesTests.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/mocks/DummyContents.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/mocks/DummyContents.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.vulnerabilities.mocks;
 
 public class DummyContents {

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/mocks/MockOctaneRestClient.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/mocks/MockOctaneRestClient.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.vulnerabilities.mocks;
 
 import com.hp.octane.integrations.OctaneConfiguration;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/mocks/MockSSCRestClient.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/services/vulnerabilities/mocks/MockSSCRestClient.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.services.vulnerabilities.mocks;
 
 import com.hp.octane.integrations.dto.securityscans.SSCProjectConfiguration;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/GeneralTestUtils.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/GeneralTestUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.testhelpers;
 
 import com.hp.octane.integrations.utils.CIPluginSDKUtils;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/OctaneSPEndpointSimulator.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/OctaneSPEndpointSimulator.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.testhelpers;
 
 import com.hp.octane.integrations.utils.CIPluginSDKUtils;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/OctaneSecuritySimulationUtils.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/OctaneSecuritySimulationUtils.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.testhelpers;
 
 import com.hp.octane.integrations.utils.CIPluginSDKUtils;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/RestServerSimulator.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/RestServerSimulator.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.testhelpers;
 
 import org.apache.http.HttpStatus;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/SSCServerSimulator.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/testhelpers/SSCServerSimulator.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.testhelpers;
 
 import com.hp.octane.integrations.services.vulnerabilities.SSCInput;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/uft/items/UftUtilsTests.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/uft/items/UftUtilsTests.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hp.octane.integrations.uft.items;
 
 import com.hp.octane.integrations.uft.UftTestDiscoveryUtils;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/utils/CIPluginSDKUtilsTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/utils/CIPluginSDKUtilsTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.utils;
 
 import com.hp.octane.integrations.exceptions.OctaneSDKGeneralException;

--- a/integrations-sdk/src/test/java/com/hp/octane/integrations/utils/OctaneUrlParserTest.java
+++ b/integrations-sdk/src/test/java/com/hp/octane/integrations/utils/OctaneUrlParserTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.hp.octane.integrations.utils;
 
 import com.hp.octane.integrations.exceptions.OctaneSDKGeneralException;

--- a/integrations-sdk/src/test/java/pullrequestsandbranches/FetchHandlerTests.java
+++ b/integrations-sdk/src/test/java/pullrequestsandbranches/FetchHandlerTests.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package pullrequestsandbranches;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/integrations-sdk/src/test/java/pullrequestsandbranches/PullRequestParsingTests.java
+++ b/integrations-sdk/src/test/java/pullrequestsandbranches/PullRequestParsingTests.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package pullrequestsandbranches;
 
 import org.junit.Assert;

--- a/integrations-sdk/src/test/java/testresults/gherkin/GherkinTestResultsCollectorTest.java
+++ b/integrations-sdk/src/test/java/testresults/gherkin/GherkinTestResultsCollectorTest.java
@@ -1,8 +1,9 @@
-/**
- * Copyright 2017-2023 Open Text
+/*
+ * Copyright 2017-2025 Open Text
  *
+ * OpenText is a trademark of Open Text.
  * The only warranties for products and services of Open Text and
- * its affiliates and licensors (“Open Text”) are as may be set forth
+ * its affiliates and licensors ("Open Text") are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
  * Open Text shall not be liable for technical or editorial errors or
@@ -28,7 +29,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package testresults.gherkin;
 
 import com.hp.octane.integrations.testresults.GherkinUtils;

--- a/integrations-sdk/src/test/java/uftTest/MbtTests.java
+++ b/integrations-sdk/src/test/java/uftTest/MbtTests.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uftTest;
 
 import com.hp.octane.integrations.dto.DTOFactory;

--- a/integrations-sdk/src/test/java/uftTest/RunResultsTestGetAggregatedError.java
+++ b/integrations-sdk/src/test/java/uftTest/RunResultsTestGetAggregatedError.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uftTest;
 
 import com.hp.octane.integrations.uft.ufttestresults.UftTestResultsUtils;

--- a/integrations-sdk/src/test/java/uftTest/UftTestDiscoveryUtilsTests.java
+++ b/integrations-sdk/src/test/java/uftTest/UftTestDiscoveryUtilsTests.java
@@ -1,3 +1,34 @@
+/*
+ * Copyright 2017-2025 Open Text
+ *
+ * OpenText is a trademark of Open Text.
+ * The only warranties for products and services of Open Text and
+ * its affiliates and licensors ("Open Text") are as may be set forth
+ * in the express warranty statements accompanying such products and services.
+ * Nothing herein should be construed as constituting an additional warranty.
+ * Open Text shall not be liable for technical or editorial errors or
+ * omissions contained herein. The information contained herein is subject
+ * to change without notice.
+ *
+ * Except as specifically indicated otherwise, this document contains
+ * confidential information and a valid license is required for possession,
+ * use or copying. If this work is provided to the U.S. Government,
+ * consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+ * Computer Software Documentation, and Technical Data for Commercial Items are
+ * licensed to the U.S. Government under vendor's standard commercial license.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uftTest;
 
 import com.hp.octane.integrations.dto.executor.impl.TestingToolType;

--- a/integrations-sdk/src/test/resources/coverage/jacoco-coverage.xml
+++ b/integrations-sdk/src/test/resources/coverage/jacoco-coverage.xml
@@ -1,3 +1,36 @@
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.0//EN"
 		"report.dtd">
 <report name="Discover Demo App - Tribute to Progressive Music (Web App)">

--- a/integrations-sdk/src/test/resources/testresults/gherkin/f1/OctaneGherkinResults0.xml
+++ b/integrations-sdk/src/test/resources/testresults/gherkin/f1/OctaneGherkinResults0.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <features version="1"><feature name="test Feature1" path="src\main\features\test2.feature" started="1467028340511" tag="@TID2001REV0.2.0"><file><![CDATA[#Auto generated NGA revision tag
 @TID2001REV0.2.0
 Feature: test Feature1

--- a/integrations-sdk/src/test/resources/testresults/gherkin/f1/OctaneGherkinResults1.xml
+++ b/integrations-sdk/src/test/resources/testresults/gherkin/f1/OctaneGherkinResults1.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 
 <features version="1"><feature name="test Feature2" path="src\main\features\test3.feature" started="1467028340511" tag="@TID2002REV0.2.0"><file><![CDATA[#Auto generated NGA revision tag
 @TID2001REV0.2.0

--- a/integrations-sdk/src/test/resources/testresults/gherkin/f2/OctaneGherkinResults0.xml
+++ b/integrations-sdk/src/test/resources/testresults/gherkin/f2/OctaneGherkinResults0.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 
 <features><feature name="test Feature1" path="src\main\features\test2.feature" started="1467028340511" tag="@TID2001REV0.2.0"><file><![CDATA[#Auto generated NGA revision tag
 @TID2001REV0.2.0

--- a/integrations-sdk/src/test/resources/testresults/gherkin/f2/OctaneGherkinResults1.xml
+++ b/integrations-sdk/src/test/resources/testresults/gherkin/f2/OctaneGherkinResults1.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 
 <features version="1"><feature name="test Feature2" path="src\main\features\test3.feature" started="1467028340511" tag="@TID2002REV0.2.0"><file><![CDATA[#Auto generated NGA revision tag
 @TID2001REV0.2.0

--- a/integrations-sdk/src/test/resources/testresults/gherkin/f3/OctaneGherkinResults0.xml
+++ b/integrations-sdk/src/test/resources/testresults/gherkin/f3/OctaneGherkinResults0.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 
 <features version="1"><feature name="test Feature1" path="src\main\features\test2.feature" started="1467028340511" tag="@TID2001REV0.2.0"><file><![CDATA[#Auto generated NGA revision tag
 @TID2001REV0.2.0

--- a/integrations-sdk/src/test/resources/testresults/gherkin/f3/OctaneGherkinResults1.xml
+++ b/integrations-sdk/src/test/resources/testresults/gherkin/f3/OctaneGherkinResults1.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 
 <features version="2"><feature name="test Feature2" path="src\main\features\test3.feature" started="1467028340511" tag="@TID2002REV0.2.0"><file><![CDATA[#Auto generated NGA revision tag
 @TID2001REV0.2.0

--- a/integrations-sdk/src/test/resources/uftTest/run_mbt_results_8_successful.xml
+++ b/integrations-sdk/src/test/resources/uftTest/run_mbt_results_8_successful.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Results version="1.0">
     <ReportNode type="testrun">
         <ReportNode type="Iteration">

--- a/integrations-sdk/src/test/resources/uftTest/run_mbt_results_with2_runs.xml
+++ b/integrations-sdk/src/test/resources/uftTest/run_mbt_results_with2_runs.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Results version="1.0">
 <ReportNode type="testrun">
 <ReportNode type="Iteration">

--- a/integrations-sdk/src/test/resources/uftTest/run_mbt_results_with_errors.xml
+++ b/integrations-sdk/src/test/resources/uftTest/run_mbt_results_with_errors.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Results version="1.0">
     <ReportNode type="testrun">
         <ReportNode type="Iteration">

--- a/integrations-sdk/src/test/resources/uftTest/run_mbt_results_with_many_errors.xml
+++ b/integrations-sdk/src/test/resources/uftTest/run_mbt_results_with_many_errors.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Results version="1.0">
 <ReportNode type="testrun">
 <ReportNode type="Iteration">

--- a/integrations-sdk/src/test/resources/uftTest/run_results.xml
+++ b/integrations-sdk/src/test/resources/uftTest/run_results.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Results version="1.0">
 <ReportNode type="testrun">
 <ReportNode type="Iteration">

--- a/integrations-sdk/src/test/resources/uftTest/run_results_GUITestWithFail.xml
+++ b/integrations-sdk/src/test/resources/uftTest/run_results_GUITestWithFail.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Results version="1.0">
 <ReportNode type="testrun">
 <ReportNode type="Iteration">

--- a/integrations-sdk/src/test/resources/uftTest/run_results_GUITestWithWarning.xml
+++ b/integrations-sdk/src/test/resources/uftTest/run_results_GUITestWithWarning.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Results version="1.0">
 <ReportNode type="testrun">
 <ReportNode type="Iteration">

--- a/integrations-sdk/src/test/resources/uftTest/run_results_computer_locked.xml
+++ b/integrations-sdk/src/test/resources/uftTest/run_results_computer_locked.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Results version="1.0">
 <ReportNode type="testrun">
 <ReportNode type="Step">

--- a/integrations-sdk/src/test/resources/uftTest/run_results_duplicatedErrors.xml
+++ b/integrations-sdk/src/test/resources/uftTest/run_results_duplicatedErrors.xml
@@ -1,4 +1,37 @@
 <?xml version="1.0"?>
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <Results version="1.0">
 <ReportNode type="testrun">
 <ReportNode type="Step">

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.hpe.adm.octane.ciplugins</groupId>
 	<artifactId>java-sdk</artifactId>
-	<version>2.24.3-SNAPSHOT</version>
+	<version>2.24.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>MicroFocus ALM Octane Common libraries for CI plugins</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,36 @@
+<!--
+
+    Copyright 2017-2025 Open Text
+
+    OpenText is a trademark of Open Text.
+    The only warranties for products and services of Open Text and
+    its affiliates and licensors ("Open Text") are as may be set forth
+    in the express warranty statements accompanying such products and services.
+    Nothing herein should be construed as constituting an additional warranty.
+    Open Text shall not be liable for technical or editorial errors or
+    omissions contained herein. The information contained herein is subject
+    to change without notice.
+
+    Except as specifically indicated otherwise, this document contains
+    confidential information and a valid license is required for possession,
+    use or copying. If this work is provided to the U.S. Government,
+    consistent with FAR 12.211 and 12.212, Commercial Computer Software,
+    Computer Software Documentation, and Technical Data for Commercial Items are
+    licensed to the U.S. Government under vendor's standard commercial license.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -78,6 +111,8 @@
 		<maven-surefire-plugin.version>3.0.0-M2</maven-surefire-plugin.version>
 		<jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
 		<spotbugs.version>3.1.9</spotbugs.version>
+		<!-- The ending year for copyright information -->
+		<copyright.end.year>2025</copyright.end.year>
 	</properties>
 
 	<dependencyManagement>
@@ -205,6 +240,45 @@
 		</pluginManagement>
 
 		<plugins>
+			<!-- This is the plugin that is used to add license headers to the source files
+                    Run the following Maven command when the license needs to pe updated:
+                    MAKE SURE THAT YOU ARE IN THE ROOT DIRECTORY OF THE PROJECT("octane-ci-java-sdk") WHEN RUNNING THIS COMMAND
+                    mvn license:format-->
+			<plugin>
+				<groupId>com.mycila</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<version>4.6</version>
+				<configuration>
+					<!-- Path to your license header -->
+					<!--suppress UnresolvedMavenProperty -->
+					<header>${session.executionRootDirectory}\LICENSE</header>
+					<strictCheck>true</strictCheck>
+					<!-- Apply to .java,.cs,.xml,.xsd,.js,.jsx,.html,.scss,.css,.xsl and .properties files -->
+					<includes>
+						<include>**/*.java</include>
+						<include>**/*.xml</include>
+						<include>**/*.properties</include>
+					</includes>
+					<!-- Define the comment styles for different file types -->
+					<mapping>
+						<java>SLASHSTAR_STYLE</java>
+						<xml>XML_STYLE</xml>
+						<properties>SCRIPT_STYLE</properties>
+					</mapping>
+					<properties>
+						<!-- Properties dynamically inserted into the license header -->
+						<copyright.end.year>${copyright.end.year}</copyright.end.year>
+					</properties>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<!-- Goal to apply the license headers to source files -->
+							<goal>format</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The com.mycila:license-maven-plugin dependency has been added to the pom.xml. This plugin is used to manage and update copyright headers in project files. 
NOTE: The license headers will only be updated when the command mvn license:format is executed from the root directory (octane-ci-java-sdk). This operation is not tied to the project's build phase and must be run separately.