### PR TITLE
defect #2512013: checked for 429 status response and retry

### DIFF
--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/coverage/CoverageServiceImpl.java
@@ -163,7 +163,7 @@ class CoverageServiceImpl implements CoverageService {
 			OctaneRequest preflightRequest = dtoFactory.newDTO(OctaneRequest.class).setMethod(HttpMethod.GET).setUrl(url);
 
 			response = restService.obtainOctaneRestClient().execute(preflightRequest);
-			if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
+			if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY || response.getStatus() == 429) {
 				throw new TemporaryException("preflight request failed with status " + response.getStatus());
 			} else if (response.getStatus() != HttpStatus.SC_OK && response.getStatus() != HttpStatus.SC_NO_CONTENT) {
 				throw new PermanentException("preflight request failed with status " + response.getStatus());
@@ -292,7 +292,7 @@ class CoverageServiceImpl implements CoverageService {
 		OctaneResponse response = pushCoverage(queueItem.jobId, queueItem.buildId, queueItem.reportType, coverageReport);
 		if (response.getStatus() == HttpStatus.SC_OK) {
 			logger.info(configurer.octaneConfiguration.getLocationForLog() + "successfully pushed coverage of " + queueItem + ", CorrelationId - " + response.getCorrelationId());
-		} else if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
+		} else if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY || response.getStatus() == 429) {
 			throw new TemporaryException("temporary failed to push coverage of " + queueItem + ", status: " + HttpStatus.SC_SERVICE_UNAVAILABLE);
 		} else {
 			throw new PermanentException("permanently failed to push coverage of " + queueItem + ", status: " + response.getStatus());

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/events/EventsServiceImpl.java
@@ -294,7 +294,7 @@ final class EventsServiceImpl implements EventsService {
 		} catch (IOException ioe) {
 			throw new TemporaryException(ioe);
 		}
-		if (octaneResponse.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || octaneResponse.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
+		if (octaneResponse.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || octaneResponse.getStatus() == HttpStatus.SC_BAD_GATEWAY || octaneResponse.getStatus() == 429) {
 			throw new TemporaryException("PUT events failed with status " + octaneResponse.getStatus());
 		} else if (octaneResponse.getStatus() == HttpStatus.SC_UNAUTHORIZED || octaneResponse.getStatus() == HttpStatus.SC_FORBIDDEN) {
 			CIPluginSDKUtils.doWait(30000);

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/logs/LogsServiceImpl.java
@@ -263,7 +263,7 @@ final class LogsServiceImpl implements LogsService {
 					.setUrl(url);
 
 			response = restService.obtainOctaneRestClient().execute(preflightRequest);
-			if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
+			if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY || response.getStatus() == 429) {
 				throw new TemporaryException("preflight request failed with status " + response.getStatus());
 			} else if (response.getStatus() == HttpStatus.SC_UNAUTHORIZED || response.getStatus() == HttpStatus.SC_FORBIDDEN) {
 				CIPluginSDKUtils.doWait(30000);

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/tests/TestsServiceImpl.java
@@ -157,7 +157,7 @@ final class TestsServiceImpl implements TestsService {
 			OctaneResponse response = restService.obtainOctaneRestClient().execute(preflightRequest);
 			if (response.getStatus() == HttpStatus.SC_OK) {
 				return String.valueOf(true).equals(response.getBody());
-			} else if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
+			} else if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY || response.getStatus() == 429) {
 				throw new TemporaryException("preflight request failed with status " + response.getStatus());
 			} else if (response.getStatus() == HttpStatus.SC_UNAUTHORIZED || response.getStatus() == HttpStatus.SC_FORBIDDEN) {
 				CIPluginSDKUtils.doWait(30000);
@@ -343,7 +343,7 @@ final class TestsServiceImpl implements TestsService {
 				if (response.getStatus() == HttpStatus.SC_ACCEPTED) {
 					logger.info(configurer.octaneConfiguration.getLocationForLog() + "successfully pushed test results for " + queueItem + "; status: " + response.getStatus() +
 							", response: " + response.getBody() + ", CorrelationId - " + response.getCorrelationId());
-				} else if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY) {
+				} else if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE || response.getStatus() == HttpStatus.SC_BAD_GATEWAY || response.getStatus() == 429) {
 					throw new TemporaryException("push request TEMPORARILY failed with status " + response.getStatus());
 				} else {
 					throw new PermanentException("push request PERMANENTLY failed with status " + response.getStatus());

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/VulnerabilitiesServiceImpl.java
@@ -293,6 +293,8 @@ public class VulnerabilitiesServiceImpl implements VulnerabilitiesService {
 			logger.info(configurer.octaneConfiguration.getLocationForLog() + "vulnerabilities push SUCCEED for " + jobId + " #" + buildId);
 		} else if (response.getStatus() == HttpStatus.SC_SERVICE_UNAVAILABLE) {
 			throw new TemporaryException("vulnerabilities push FAILED, service unavailable");
+		} else if (response.getStatus() == 429) {
+			throw new TemporaryException("vulnerabilities push FAILED, to many requests");
 		} else {
 			throw new PermanentException("vulnerabilities push FAILED, status " + response.getStatus() + "; dropping this item from the queue \n" + response.getBody());
 		}

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODConnector.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/vulnerabilities/fod/dto/FODConnector.java
@@ -193,6 +193,9 @@ public class FODConnector implements FODSource {
 				if(response.getStatusLine().getStatusCode() == 503){
 					throw new TemporaryException("Service Unavailable ,  retry");
 				}
+				if(response.getStatusLine().getStatusCode() == 429){
+					throw new TemporaryException("Too Many Requests,  retry");
+				}
 				if(response.getStatusLine().getStatusCode() == 500){
 					throw new PermanentException("Internal FOD Server Error 500, failed to get vulnerability, httpGet: " + httpGet + "  unexpected return response : " +response.getStatusLine().getReasonPhrase());
 				}


### PR DESCRIPTION
link to BL:
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2512013

Description:
Octane may limit the number of requests per time unit and because of that a 429 status is returned as a response.

Solution:
I treated the 429 as a temporary problem and retried the request.