### PR TITLE
defect #2408006: if sharedspace does not exist stop sending req to octane

### DIFF
--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/services/bridge/BridgeServiceImpl.java
@@ -220,7 +220,7 @@ final class BridgeServiceImpl implements BridgeService {
     }
 
     private String getAbridgedTasks(String selfIdentity, String selfType, String selfUrl, String pluginVersion, String octaneUser, String ciServerUser) {
-        if (failedSharedSpaces.contains(configurer.octaneConfiguration.getSharedSpace())) {
+        if (failedSharedSpaces.contains(configurer.octaneConfiguration.getSharedSpace() + configurer.octaneConfiguration.getInstanceId())) {
             return null;
         }
 
@@ -258,7 +258,7 @@ final class BridgeServiceImpl implements BridgeService {
                     logger.debug(configurer.octaneConfiguration.getLocationForLog() + "no tasks found on server");
                     setConnectionSuccessful();
                 } else if (CIPluginSDKUtils.isSharedSpaceIllegal(octaneResponse.getBody())) {
-                    failedSharedSpaces.add(configurer.octaneConfiguration.getSharedSpace());
+                    failedSharedSpaces.add(configurer.octaneConfiguration.getSharedSpace() + configurer.octaneConfiguration.getInstanceId());
                 } else if (octaneResponse.getStatus() == HttpStatus.SC_REQUEST_TIMEOUT) {
                     logger.debug(configurer.octaneConfiguration.getLocationForLog() + "expected timeout disconnection on retrieval of abridged tasks, reconnecting immediately...");
                     setConnectionSuccessful();

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/CIPluginSDKUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/CIPluginSDKUtils.java
@@ -292,7 +292,7 @@ public class CIPluginSDKUtils {
 	}
 
 	public static boolean isSharedSpaceIllegal(String body) {
-		return body != null && body.contains("illegal sharedspace");
+		return body != null && body.contains("requests with illegal sharedspace ID");
 		//Received requests with illegal sharedspace ID
 	}
 

--- a/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/CIPluginSDKUtils.java
+++ b/integrations-sdk/src/main/java/com/hp/octane/integrations/utils/CIPluginSDKUtils.java
@@ -291,6 +291,11 @@ public class CIPluginSDKUtils {
 		//Service Temporarily Unavailable"
 	}
 
+	public static boolean isSharedSpaceIllegal(String body) {
+		return body != null && body.contains("illegal sharedspace");
+		//Received requests with illegal sharedspace ID
+	}
+
 	/**
 	 *
 	 * @param jobId current job id


### PR DESCRIPTION
Defect:
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=2408006

Problem:
SDK sent requests to Octane when the shared space after Octane was deleted.

Solution:
Remember what shared spaces were deleted from the Octane side and skip requests to Octane for those shared spaces.